### PR TITLE
fix(go): add API key client configuration

### DIFF
--- a/go/README.md
+++ b/go/README.md
@@ -21,6 +21,17 @@ Get the ScopeDB GO SDK source code, if not installed.
 go get -u github.com/scopedb/scopedb-sdk/go
 ```
 
+## Usage
+
+Create a client with your ScopeDB endpoint and API key:
+
+```go
+client := scopedb.NewClient(&scopedb.Config{
+	Endpoint: "https://your-tenant.scopedb.io",
+	APIKey:   os.Getenv("SCOPEDB_API_KEY"),
+})
+```
+
 ## Docs
 
 For detailed documentation and basic usage examples, please see the documentation at [godoc.org](https://godoc.org/github.com/scopedb/scopedb-sdk/go).

--- a/go/client.go
+++ b/go/client.go
@@ -40,7 +40,8 @@ func NewClient(config *Config) *Client {
 	return &Client{
 		config: config,
 		http: &httpClient{
-			client: http.DefaultClient,
+			client:        http.DefaultClient,
+			authorization: bearerAuthorization(config),
 		},
 	}
 }
@@ -56,7 +57,8 @@ func (c *Client) Close() {
 
 // httpClient is a wrapper around the standard http.Client to decorate GET/POST requests.
 type httpClient struct {
-	client *http.Client
+	client        *http.Client
+	authorization string
 }
 
 // doGet sends a GET request to the ScopeDB server.
@@ -65,6 +67,7 @@ func (c *httpClient) doGet(ctx context.Context, u *url.URL) (*http.Response, err
 	if err != nil {
 		return nil, err
 	}
+	c.applyAuthorization(req)
 	resp, err := c.client.Do(req)
 	return resp, err
 }
@@ -89,8 +92,16 @@ func (c *httpClient) doPost(ctx context.Context, u *url.URL, body []byte) (*http
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Content-Encoding", "gzip")
 	req.Header.Set("X-ScopeDB-Uncompressed-Content-Length", strconv.Itoa(uncompressedContentLength))
+	c.applyAuthorization(req)
 	resp, err := c.client.Do(req)
 	return resp, err
+}
+
+func (c *httpClient) applyAuthorization(req *http.Request) {
+	if c.authorization == "" {
+		return
+	}
+	req.Header.Set("Authorization", c.authorization)
 }
 
 // Close closes the HTTP client.
@@ -100,6 +111,13 @@ func (c *httpClient) doPost(ctx context.Context, u *url.URL, body []byte) (*http
 // useful to call this if you want to release the resources immediately.
 func (c *httpClient) Close() {
 	c.client.CloseIdleConnections()
+}
+
+func bearerAuthorization(config *Config) string {
+	if config == nil || config.APIKey == "" {
+		return ""
+	}
+	return "Bearer " + config.APIKey
 }
 
 type statementRequest struct {

--- a/go/config.go
+++ b/go/config.go
@@ -20,4 +20,9 @@ package scopedb
 type Config struct {
 	// Endpoint is the URL of the ScopeDB service.
 	Endpoint string `json:"endpoint"`
+	// APIKey is the API key used for authentication.
+	//
+	// When provided, the client sends it as the Authorization header using the
+	// Bearer scheme.
+	APIKey string `json:"api_key"`
 }

--- a/go/doc.go
+++ b/go/doc.go
@@ -23,6 +23,7 @@ Use NewClient to create a client struct. This is the major entrance to construct
 
 	client := scopedb.NewClient(&scopedb.Config{
 		Endpoint: "http://<scopedb-host>:<scopedb-port:-6543>",
+		APIKey:   "<scopedb-api-key>",
 	})
 
 # Write Data via Cables


### PR DESCRIPTION
## Summary
- add `APIKey` to the Go SDK client config
- send `Authorization: Bearer <api-key>` on Go SDK requests when configured
- document API key usage in the Go SDK docs and README

## Testing
- `go test ./...`
- temporary end-to-end verification with local ScopeQL config (`/Users/leiysky/.scopeql/config.toml`), without adding repo tests