### PR TITLE
chore(go): post release 0.4.0

### DIFF
--- a/go/README.md
+++ b/go/README.md
@@ -40,8 +40,8 @@ For detailed documentation and basic usage examples, please see the documentatio
 
 | Go SDK Version | ScopeDB Version |
 | -------------- | --------------- |
-| 0.3.0          | >= 0.1.116      |
-| < 0.3.0        | archived        |
+| 0.3.1          | >= 0.1.116      |
+| <= 0.3.0       | archived        |
 
 ## Development
 

--- a/go/README.md
+++ b/go/README.md
@@ -40,7 +40,7 @@ For detailed documentation and basic usage examples, please see the documentatio
 
 | Go SDK Version | ScopeDB Version |
 | -------------- | --------------- |
-| 0.3.1          | >= 0.1.116      |
+| 0.4.0          | >= 0.1.116      |
 | <= 0.3.0       | archived        |
 
 ## Development


### PR DESCRIPTION
## Summary
- update the Go SDK compatibility table for the 0.4.0 release
- mark `0.4.0` as the current Go SDK version
- archive `<= 0.3.0` in the compatibility matrix

## Testing
- not run (README-only release metadata update)