### PR TITLE
fix(go): convert binary and interval result values

### DIFF
--- a/go/CHANGELOG.md
+++ b/go/CHANGELOG.md
@@ -4,6 +4,11 @@ All significant changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Bug Fixes
+
+* Added the missing binary and null data type constants.
+* Fixed `ResultSet.ToValues` conversion for binary and interval columns.
+
 ## v0.5.0 (2026-04-23)
 
 ### Breaking Changes

--- a/go/client.go
+++ b/go/client.go
@@ -21,6 +21,7 @@ import (
 	"compress/gzip"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -137,8 +138,7 @@ func compressRequestBody(body []byte, compression Compression) (bytes.Buffer, Co
 			return bytes.Buffer{}, "", err
 		}
 		if _, err := zw.Write(body); err != nil {
-			zw.Close()
-			return bytes.Buffer{}, "", err
+			return bytes.Buffer{}, "", errors.Join(err, zw.Close())
 		}
 		if err := zw.Close(); err != nil {
 			return bytes.Buffer{}, "", err

--- a/go/client_test.go
+++ b/go/client_test.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -119,8 +120,8 @@ func decodeCompressedRequestBody(r *http.Request) ([]byte, error) {
 		if err != nil {
 			return nil, err
 		}
-		defer gr.Close()
-		return io.ReadAll(gr)
+		decoded, readErr := io.ReadAll(gr)
+		return decoded, errors.Join(readErr, gr.Close())
 	default:
 		return nil, io.ErrUnexpectedEOF
 	}

--- a/go/result.go
+++ b/go/result.go
@@ -17,12 +17,17 @@
 package scopedb
 
 import (
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"regexp"
 	"strconv"
+	"strings"
 	"time"
 )
+
+var fixedDurationPattern = regexp.MustCompile(`^(-)?PT(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)(?:\.(\d{1,9}))?S)?$`)
 
 // Value stores the contents of a single cell from a ScopeDB statement result.
 type Value any
@@ -42,6 +47,10 @@ type ResultSet struct {
 // ToValues reads the result set and returns the rows as a 2D array of values,
 // i.e., rows of value lists.
 //
+// Binary cells are returned as []byte, timestamps as time.Time, and intervals
+// as time.Duration. Array, object, and any cells remain JSON strings, while
+// null cells are returned as nil.
+//
 // This method is only valid if the result set is of the JSON format.
 func (rs *ResultSet) ToValues() ([][]Value, error) {
 	if rs.Format != ResultFormatJSON {
@@ -57,6 +66,12 @@ func (rs *ResultSet) ToValues() ([][]Value, error) {
 		switch typ {
 		case StringDataType:
 			return v, nil
+		case BinaryDataType:
+			value, err := hex.DecodeString(v)
+			if err != nil {
+				return nil, fmt.Errorf("invalid binary value %q: %w", v, err)
+			}
+			return value, nil
 		case IntDataType:
 			return strconv.ParseInt(v, 10, 64)
 		case UIntDataType:
@@ -68,10 +83,12 @@ func (rs *ResultSet) ToValues() ([][]Value, error) {
 		case TimestampDataType:
 			return time.Parse(time.RFC3339Nano, v)
 		case IntervalDataType:
-			return time.ParseDuration(v)
+			return parseInterval(v)
 		case ArrayDataType, ObjectDataType, AnyDataType:
 			// represent as JSON string
 			return v, nil
+		case NullDataType:
+			return nil, fmt.Errorf("unexpected non-null value for null data type: %q", v)
 		default:
 			return nil, fmt.Errorf("unrecognized type: %s", typ)
 		}
@@ -101,6 +118,26 @@ func (rs *ResultSet) ToValues() ([][]Value, error) {
 	return valueLists, nil
 }
 
+func parseInterval(value string) (time.Duration, error) {
+	matches := fixedDurationPattern.FindStringSubmatch(value)
+	if matches == nil || matches[2]+matches[3]+matches[4] == "" {
+		return 0, fmt.Errorf("invalid interval value %q: expected fixed-duration ISO 8601 PT form", value)
+	}
+
+	duration := strings.TrimPrefix(value, "-")
+	duration = strings.TrimPrefix(duration, "PT")
+	duration = strings.NewReplacer("H", "h", "M", "m", "S", "s").Replace(duration)
+	if matches[1] == "-" {
+		duration = "-" + duration
+	}
+
+	parsed, err := time.ParseDuration(duration)
+	if err != nil {
+		return 0, fmt.Errorf("invalid interval value %q: %w", value, err)
+	}
+	return parsed, nil
+}
+
 // Schema describes the fields in a table or query result.
 type Schema []*FieldSchema
 
@@ -118,6 +155,8 @@ type DataType string
 const (
 	// StringDataType indicates the data is of string data type.
 	StringDataType DataType = "string"
+	// BinaryDataType indicates the data is of binary data type.
+	BinaryDataType DataType = "binary"
 	// IntDataType indicates the data is of int data type.
 	IntDataType DataType = "int"
 	// UIntDataType indicates the data is of uint data type.
@@ -136,4 +175,6 @@ const (
 	ObjectDataType DataType = "object"
 	// AnyDataType indicates the data is of any data type.
 	AnyDataType DataType = "any"
+	// NullDataType indicates the data is of null data type.
+	NullDataType DataType = "null"
 )

--- a/go/result_test.go
+++ b/go/result_test.go
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2024 ScopeDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package scopedb
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestResultSetToValuesConvertsBinaryAndInterval(t *testing.T) {
+	t.Parallel()
+
+	rows, err := json.Marshal([][]*string{{
+		stringPointer("0001ABFF"),
+		stringPointer(""),
+		stringPointer("abcdef"),
+		stringPointer("PT1H2M3.000000004S"),
+		stringPointer("-PT1M0.000000001S"),
+		nil,
+	}})
+	require.NoError(t, err)
+
+	resultSet := &ResultSet{
+		Schema: Schema{
+			&FieldSchema{Name: "payload", Type: BinaryDataType},
+			&FieldSchema{Name: "empty_payload", Type: BinaryDataType},
+			&FieldSchema{Name: "lowercase_payload", Type: BinaryDataType},
+			&FieldSchema{Name: "elapsed", Type: IntervalDataType},
+			&FieldSchema{Name: "offset", Type: IntervalDataType},
+			&FieldSchema{Name: "nothing", Type: NullDataType},
+		},
+		Format: ResultFormatJSON,
+		rows:   rows,
+	}
+
+	values, err := resultSet.ToValues()
+	require.NoError(t, err)
+	require.Equal(t, [][]Value{{
+		[]byte{0x00, 0x01, 0xab, 0xff},
+		[]byte{},
+		[]byte{0xab, 0xcd, 0xef},
+		time.Hour + 2*time.Minute + 3*time.Second + 4*time.Nanosecond,
+		-time.Minute - time.Nanosecond,
+		nil,
+	}}, values)
+}
+
+func TestResultSetToValuesConvertsIntervalBoundaries(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]time.Duration{
+		"PT0S":                        0,
+		"PT24H":                       24 * time.Hour,
+		"PT2562047H47M16.854775807S":  time.Duration(1<<63 - 1),
+		"-PT2562047H47M16.854775808S": time.Duration(-1 << 63),
+	}
+	for value, expected := range tests {
+		value, expected := value, expected
+		t.Run(value, func(t *testing.T) {
+			t.Parallel()
+
+			resultSet := resultSetWithSingleValue(IntervalDataType, value)
+			values, err := resultSet.ToValues()
+			require.NoError(t, err)
+			require.Equal(t, expected, values[0][0])
+		})
+	}
+}
+
+func TestResultSetToValuesRejectsInvalidBinary(t *testing.T) {
+	t.Parallel()
+
+	resultSet := resultSetWithSingleValue(BinaryDataType, "not-hex")
+
+	_, err := resultSet.ToValues()
+	require.ErrorContains(t, err, `invalid binary value "not-hex"`)
+}
+
+func TestResultSetToValuesRejectsInvalidInterval(t *testing.T) {
+	t.Parallel()
+
+	for _, value := range []string{"1h", "P1D", "PT", "PT1.0000000000S", "PT2562048H"} {
+		value := value
+		t.Run(value, func(t *testing.T) {
+			t.Parallel()
+
+			resultSet := resultSetWithSingleValue(IntervalDataType, value)
+			_, err := resultSet.ToValues()
+			require.ErrorContains(t, err, "invalid interval value")
+		})
+	}
+}
+
+func TestResultSetToValuesRejectsNonNullValueForNullType(t *testing.T) {
+	t.Parallel()
+
+	resultSet := resultSetWithSingleValue(NullDataType, "null")
+
+	_, err := resultSet.ToValues()
+	require.ErrorContains(t, err, "unexpected non-null value for null data type")
+}
+
+func resultSetWithSingleValue(dataType DataType, value string) *ResultSet {
+	rows, err := json.Marshal([][]*string{{stringPointer(value)}})
+	if err != nil {
+		panic(err)
+	}
+	return &ResultSet{
+		Schema: Schema{&FieldSchema{Name: "value", Type: dataType}},
+		Format: ResultFormatJSON,
+		rows:   rows,
+	}
+}
+
+func stringPointer(value string) *string {
+	return &value
+}


### PR DESCRIPTION
## Summary

- decode binary statement result cells from hexadecimal into `[]byte`
- parse the current fixed-duration ISO 8601 `PT…` interval wire format into `time.Duration`
- expose the missing `BinaryDataType` and `NullDataType` constants
- propagate compression close errors uncovered by the full static check

## Why

`ResultSet.ToValues` did not recognize binary fields and passed ScopeDB's ISO 8601 interval strings directly to `time.ParseDuration`. Valid binary and interval query results therefore returned conversion errors.

ScopeDB and the SDK are still pre-release, so this change intentionally supports the current `PT…` interval contract only; legacy Go-duration strings such as `1h` remain invalid.

## Impact

Go callers can consume binary values as bytes and fixed-duration intervals as `time.Duration`. Invalid hexadecimal, calendar-duration syntax, excessive fractional precision, and duration overflow return explicit errors.

## Validation

- `cd go && just check`
- `cd go && just build`
- `cd go && just test`

The local integration cases were skipped because `SCOPEDB_ENDPOINT` is not set; CI runs them with the repository endpoint secret.