### PR TITLE
feat(rust): add streaming writes and catalog api

### DIFF
--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -18,6 +18,7 @@ on:
     branches: [ main ]
     paths: [
       'rust/**',
+      'docs/rust-http-api.md',
       '.github/workflows/ci-rust.yml',
     ]
   schedule:
@@ -40,7 +41,7 @@ jobs:
           components: rustfmt,clippy
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@just
-      - name: Check Go SDK
+      - name: Check Rust SDK
         run: just check
         working-directory: rust
 
@@ -49,6 +50,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
+      - name: Install MSRV toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.85.0
       - uses: taiki-e/install-action@just
       - name: Run full tests
         timeout-minutes: 10
@@ -65,10 +70,16 @@ jobs:
     steps:
       - name: Guardian
         run: |
-          if [[ ! ( \
-                 ("${{ needs.check.result }}" == "success" || ${{ github.event_name != 'schedule' }}) \
-              && "${{ needs.test.result }}" == "success" \
-              ) ]]; then
-            echo "Required jobs haven't been completed successfully."
-            exit -1
+          check_result="${{ needs.check.result }}"
+          test_result="${{ needs.test.result }}"
+          event_name="${{ github.event_name }}"
+
+          if [[ "$test_result" != "success" ]]; then
+            echo "The test job did not complete successfully: $test_result"
+            exit 1
+          fi
+
+          if [[ "$event_name" != "schedule" && "$check_result" != "success" ]]; then
+            echo "The check job did not complete successfully: $check_result"
+            exit 1
           fi

--- a/docs/rust-http-api.md
+++ b/docs/rust-http-api.md
@@ -1,36 +1,229 @@
-# Rust HTTP API Reference
+# Rust HTTP API reference
 
-This document describes the public HTTP API surface used by the Rust SDK.
-It is intended as a maintenance reference for the SDK implementation and for
-examples in this repository.
+This document describes the HTTP surface modeled by the Rust SDK and the
+delivery rules that its higher-level helpers preserve. Public endpoints are
+rooted at `/v1`.
 
-## Base URL
-
-All public endpoints are rooted at `/v1`.
-
-## Endpoints
+## Health
 
 ### `GET /v1/health`
 
-Returns a plain-text health response:
+Returns a plain-text connectivity and liveness response:
 
 ```text
 OK
 ```
 
-This endpoint is suitable for connectivity and liveness checks.
+## REST catalog API
 
-### `GET /v1/version`
+Catalog endpoints are read-only. Every user-provided database, schema, and
+table name occupies one URL path segment; the SDK percent-encodes those segments.
 
-Returns a JSON version payload for the service.
+### Databases
 
-The Rust SDK does not currently model this response as a typed API.
+```text
+GET /v1/databases
+GET /v1/databases/{database}
+```
+
+### Schemas
+
+```text
+GET /v1/databases/{database}/schemas
+GET /v1/databases/{database}/schemas/{schema}
+```
+
+### Tables
+
+```text
+GET /v1/databases/{database}/schemas/{schema}/tables
+GET /v1/databases/{database}/schemas/{schema}/tables/{table}
+```
+
+### Pagination
+
+All list endpoints accept:
+
+- `page_size`: optional integer from 1 through 1000; the default is 100
+- `page_token`: optional opaque token returned by the previous page
+
+The Rust SDK exposes these as `CatalogListOptions`. A list response has the same
+shape for every resource type:
+
+```json
+{
+  "items": [],
+  "next_page_token": "opaque-token"
+}
+```
+
+`next_page_token` is omitted when there is no next page. Clients must pass it
+back unchanged and must not parse or synthesize it.
+
+### Resource shapes
+
+Database:
+
+```json
+{
+  "name": "scopedb",
+  "comment": "optional description"
+}
+```
+
+Schema:
+
+```json
+{
+  "database": "scopedb",
+  "name": "public",
+  "comment": "optional description"
+}
+```
+
+Table list endpoints return summaries:
+
+```json
+{
+  "database": "scopedb",
+  "schema": "public",
+  "name": "events",
+  "comment": "optional description"
+}
+```
+
+Fetching one table returns its full public specification:
+
+```json
+{
+  "database": "scopedb",
+  "schema": "public",
+  "name": "events",
+  "columns": [
+    {
+      "name": "occurred_at",
+      "data_type": "timestamp",
+      "comment": null
+    }
+  ],
+  "partition_by": [],
+  "cluster_by": [],
+  "distinct_on": {
+    "on": [],
+    "by": []
+  },
+  "data_retention_days": null,
+  "comment": null
+}
+```
+
+## Streaming write API
+
+The streaming write API appends rows that already match an existing table. It
+supports NDJSON only.
+
+### `POST /v1/databases/{database}/schemas/{schema}/tables/{table}/rows`
+
+Required request header:
+
+```http
+Content-Type: application/x-ndjson
+```
+
+Request body:
+
+```ndjson
+{"id":1,"name":"first"}
+{"id":2,"name":"second"}
+```
+
+Each line is one complete JSON row object. A JSON array is not a valid
+replacement for multiple NDJSON lines. The body must not be empty. One request
+is limited to 16 MiB and 200,000 rows.
+
+A committed response is:
+
+```json
+{
+  "append_state": "committed",
+  "num_rows_inserted": 2
+}
+```
+
+The Rust SDK accepts success only when `append_state` is `committed` and the
+inserted row count is valid. A malformed or contradictory success response has
+an unknown commit outcome.
+
+### Structured append errors
+
+An append failure uses this payload when the outcome is known:
+
+```json
+{
+  "message": "row validation failed",
+  "append_state": "rejected",
+  "row_errors": [
+    {
+      "row_index": 0,
+      "column": "id",
+      "message": "invalid value"
+    }
+  ],
+  "row_errors_truncated": false
+}
+```
+
+`append_state` has three meanings:
+
+- `committed`: all request rows committed
+- `rejected`: no request row committed
+- `unknown`: the commit outcome cannot be determined
+
+`row_index` is zero-based within the submitted NDJSON request. The server may
+truncate the row-error list; `row_errors_truncated` preserves that fact.
+
+Transport errors, response-body read failures, attempt timeouts, and malformed
+responses are classified as `unknown`, because the request may have reached the
+commit path. Replaying an unknown payload may insert duplicates.
+
+The asynchronous append stream retries only the same HTTP batch when both of
+these conditions hold:
+
+1. The structured response explicitly says `append_state: "rejected"`.
+2. The HTTP failure is temporary.
+
+It never automatically retries an unknown batch. Direct `Table::append` and
+`Client::append_rows` return the structured error to the caller and do not own a
+retry loop.
+
+### Client-side batching and barriers
+
+`Table::append_stream` is a client-side batching layer over the rows endpoint;
+it is not a separate HTTP endpoint.
+
+- Every accepted Rust value is serialized to exactly one NDJSON line.
+- `send` and `send_all` wait for local admission capacity, not a remote commit.
+- `try_send` attempts local admission immediately.
+- Size and time thresholds seal batches.
+- `max_in_flight_requests` bounds concurrent append requests.
+- `max_pending_bytes` bounds accepted serialized data that has not settled.
+- `flush` settles all rows accepted before its barrier.
+- `shutdown` closes admission and settles the final accepted prefix.
+
+With the default `Stop` failure policy, a failed batch makes the stream terminal
+and barriers return an error. With `Continue`, rejected and unknown batches are
+accounted for and released so later batches can proceed. Continue-mode barriers
+return an `AppendDeliveryReport`; they do not imply that every row committed.
+
+Concurrent batches do not have a defined commit order. Set the in-flight limit
+to one when requests must be submitted serially. Neither policy provides a
+stream-wide transaction, rollback, durable replay queue, or idempotency.
+
+## Statement API
 
 ### `POST /v1/statements`
 
 Submits a statement for execution.
-
-Request body:
 
 ```json
 {
@@ -48,45 +241,21 @@ Request fields:
 - `statement`: required
 - `exec_timeout`: optional
 - `max_parallelism`: optional
-- `format`: always `json` for the current public Rust SDK
+- `format`: `json` for the public Rust SDK
 
-The service may support additional wire encodings, but the Rust SDK does not
-expose them as public request options.
+The response is a tagged statement-state payload: `pending`, `running`,
+`finished`, `failed`, or `cancelled`. Statement failure and cancellation are
+in-band states, so HTTP success does not imply statement success.
 
-Response body:
+### `GET /v1/statements/{statement_id}?format=json`
 
-- `pending`
-- `running`
-- `finished`
-- `failed`
-- `cancelled`
-
-All of the above are represented as tagged statement-state payloads.
-
-Important behavior:
-
-- Statement failure and cancellation are represented in-band as statement-state payloads.
-- Transport-level success does not imply statement-level success.
-- Request validation and transport failures are returned as non-2xx responses.
-
-### `GET /v1/statements/{statement_id}?format=...`
-
-Fetches the latest state for a submitted statement.
-
-Query params:
-
-- `format`: always `json` for the current public Rust SDK
-
-Response behavior:
-
-- Returns the same statement-state payload family as `POST /v1/statements`
-- Returns a non-2xx response if the statement does not exist
+Fetches the latest state for a submitted statement and returns the same state
+payload family as statement submission.
 
 ### `POST /v1/statements/{statement_id}/cancel`
 
-Cancels a pending or running statement.
-
-Response body:
+Cancels a pending or running statement. The response contains the post-cancel
+terminal status view:
 
 ```json
 {
@@ -97,70 +266,16 @@ Response body:
 }
 ```
 
-Notes:
+### Statement result shape
 
-- The response returns the post-cancel terminal status view
-- A missing statement is returned as a non-2xx response
-
-### `POST /v1/ingest`
-
-Ingests rows through a transform statement.
-
-Request body:
-
-```json
-{
-  "type": "committed",
-  "data": {
-    "format": "json",
-    "rows": "{\"k\":1}\n{\"k\":2}"
-  },
-  "statement": "SELECT ... INSERT INTO target_table"
-}
-```
-
-Supported data payloads used by the Rust SDK:
-
-- `{"format":"json","rows":"...json lines..."}`
-
-Supported ingest type values:
-
-- `committed`
-
-Response body:
-
-```json
-{
-  "num_rows_inserted": 2
-}
-```
-
-## Error Response Shape
-
-For non-2xx request failures, the response body is generally shaped as:
-
-```json
-{
-  "message": "..."
-}
-```
-
-The Rust SDK should therefore distinguish:
-
-- transport or deserialization errors
-- non-2xx server error payloads
-- in-band statement failures represented as `failed` or `cancelled` statement states
-
-## Statement Result Shape
-
-A finished statement contains a `result_set` payload:
+A finished statement contains a JSON result set:
 
 ```json
 {
   "status": "finished",
   "statement_id": "uuid",
   "created_at": "timestamp",
-  "progress": { "...": "..." },
+  "progress": {},
   "result_set": {
     "metadata": {
       "fields": [
@@ -174,10 +289,43 @@ A finished statement contains a `result_set` payload:
 }
 ```
 
-The public Rust SDK currently requests JSON results only, so the main
-high-level row-conversion path is JSON-oriented.
+## Transform-oriented ingest API
 
-## SDK Notes
+### `POST /v1/ingest`
 
-- A higher-level polling helper must inspect statement status rather than rely only on HTTP status codes.
-- A higher-level ingest helper may treat record serialization as an SDK concern while keeping the HTTP payload in JSON-lines form.
+Ingests JSON lines through a transformation statement.
+
+```json
+{
+  "type": "committed",
+  "data": {
+    "format": "json",
+    "rows": "{\"k\":1}\n{\"k\":2}"
+  },
+  "statement": "SELECT ... INSERT INTO target_table"
+}
+```
+
+The Rust SDK uses committed ingest with JSON-line data. A successful response is:
+
+```json
+{
+  "num_rows_inserted": 2
+}
+```
+
+This endpoint is useful when each input record needs a SQL transform. For rows
+already shaped like a table, use the streaming write API.
+
+## Generic error responses
+
+Non-append non-2xx responses generally use:
+
+```json
+{
+  "message": "..."
+}
+```
+
+The SDK distinguishes transport or deserialization errors, non-2xx server
+errors, structured append outcomes, and in-band statement terminal states.

--- a/rust/README.md
+++ b/rust/README.md
@@ -1,42 +1,274 @@
 # ScopeDB SDK for Rust
 
-This crate provides a Rust client for ScopeDB.
+`scopedb-client` is an async Rust client for ScopeDB. It supports statements,
+read-only REST catalog discovery, direct NDJSON table appends, bounded concurrent
+streaming writes, and transform-oriented JSON ingest.
 
 ## Installation
 
-```toml
-[dependencies]
-scopedb-client = "0.2"
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
-tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+```sh
+cargo add scopedb-client reqwest serde_json
+cargo add tokio --features macros,rt-multi-thread
 ```
 
-## Create a Client
+## Create a client
+
+The SDK accepts a configured `reqwest::Client`, so applications can own TLS,
+timeouts, authentication headers, and connection pooling.
 
 ```rust
 use scopedb_client::Client;
 
-let client = Client::new("http://127.0.0.1:6543", reqwest::Client::new())?;
+let client = Client::new(
+    "http://127.0.0.1:6543",
+    reqwest::Client::new(),
+)?;
 # Ok::<(), scopedb_client::Error>(())
 ```
 
-## Run a Statement
+## Run a statement
 
 ```rust
 # async fn demo() -> Result<(), scopedb_client::Error> {
 # let client = scopedb_client::Client::new("http://127.0.0.1:6543", reqwest::Client::new())?;
-let result = client
-    .statement("SELECT 1".to_string())
-    .execute()
-    .await?;
-
+let result = client.statement("SELECT 1".to_string()).execute().await?;
 let rows = result.into_values()?;
 println!("{rows:?}");
 # Ok(())
 # }
 ```
 
-## Table Helper
+## Browse the catalog
+
+Catalog list methods return one page and preserve the opaque continuation token.
+Fetch methods return the full database, schema, or table resource.
+
+```rust
+use scopedb_client::CatalogListOptions;
+
+# async fn demo() -> Result<(), scopedb_client::Error> {
+# let client = scopedb_client::Client::new("http://127.0.0.1:6543", reqwest::Client::new())?;
+let databases = client
+    .list_databases(CatalogListOptions {
+        page_size: Some(100),
+        page_token: None,
+    })
+    .await?;
+
+let database = client.fetch_database("scopedb").await?;
+let schemas = client
+    .list_schemas("scopedb", CatalogListOptions::default())
+    .await?;
+let schema = client.fetch_schema("scopedb", "public").await?;
+let tables = client
+    .list_tables("scopedb", "public", CatalogListOptions::default())
+    .await?;
+let table = client
+    .fetch_table("scopedb", "public", "events")
+    .await?;
+
+println!("{} {} {}", database.name, schema.name, table.name);
+println!("first page: {} databases, {} schemas, {} tables", databases.items.len(), schemas.items.len(), tables.items.len());
+# Ok(())
+# }
+```
+
+See [`examples/catalog.rs`](examples/catalog.rs) for complete database
+pagination and table metadata discovery.
+
+## Streaming writes with NDJSON
+
+The table write API accepts newline-delimited JSON only: each line is one JSON
+row object. It does not accept a JSON array. The destination table must already
+exist. `Table` uses `scopedb` and `public` when the database or schema is not
+specified.
+
+### Direct append
+
+Use direct append when the caller already owns one exact NDJSON request boundary.
+
+```rust
+use scopedb_client::Client;
+
+# async fn demo() -> Result<(), scopedb_client::Error> {
+# let client = Client::new("http://127.0.0.1:6543", reqwest::Client::new())?;
+let table = client
+    .table("events")
+    .with_database("scopedb")
+    .with_schema("public");
+
+let ndjson = [
+    serde_json::json!({"id": 1, "name": "first"}),
+    serde_json::json!({"id": 2, "name": "second"}),
+]
+.iter()
+.map(serde_json::to_string)
+.collect::<Result<Vec<_>, _>>()
+.expect("example rows serialize")
+.join("\n");
+
+let result = table.append(ndjson).await?;
+println!("committed remotely: {} rows", result.num_rows_inserted);
+# Ok(())
+# }
+```
+
+A failed append exposes structured details through `Error::append_details()`:
+
+```rust
+use scopedb_client::AppendState;
+use scopedb_client::ErrorKind;
+
+# fn inspect(error: &scopedb_client::Error) {
+if error.kind() == ErrorKind::AppendRowsFailed {
+    if let Some(details) = error.append_details() {
+        match details.append_state {
+            AppendState::Rejected => {
+                eprintln!("request rejected: {:?}", details.row_errors);
+            }
+            AppendState::Unknown => {
+                eprintln!("rows may have committed; reconcile before replaying");
+            }
+            AppendState::Committed => {}
+        }
+    }
+}
+# }
+```
+
+`Unknown` is deliberately different from a rejection: replaying the same rows
+may insert duplicates.
+
+### Asynchronous append stream
+
+Use `append_stream()` for continuous or large producers. The stream serializes
+records to NDJSON, batches by size or time, bounds pending bytes, and sends a
+bounded number of HTTP append requests concurrently.
+
+```rust
+use std::time::Duration;
+
+# async fn demo() -> Result<(), scopedb_client::Error> {
+# let client = scopedb_client::Client::new("http://127.0.0.1:6543", reqwest::Client::new())?;
+let table = client.table("events").with_schema("public");
+let stream = table
+    .append_stream()
+    .batch_bytes(4 * 1024 * 1024)
+    .flush_interval(Duration::from_secs(1))
+    .max_in_flight_requests(4)
+    .max_pending_bytes(64 * 1024 * 1024)
+    .build()?;
+
+let admitted = stream
+    .send_all([
+        serde_json::json!({"id": 1, "name": "first"}),
+        serde_json::json!({"id": 2, "name": "second"}),
+    ])
+    .await?;
+println!("accepted locally: {} rows", admitted.accepted_rows);
+
+// Remote delivery barrier for every row accepted before this call.
+let report = stream.flush().await?;
+println!("committed remotely: {} rows", report.committed_rows);
+
+// Closes admission, flushes remaining rows, and settles in-flight requests.
+stream.shutdown().await?;
+# Ok(())
+# }
+```
+
+`send()` and `send_all()` wait for local admission capacity only; they do not
+wait for a remote commit. Feed an iterator sequentially instead of spawning one
+task per row, which would move the unbounded backlog outside the stream.
+`flush()` and `shutdown()` are remote delivery barriers.
+
+Once a `flush()` future has enqueued its barrier, dropping that future does not
+cancel remote settlement. Keep it alive to receive the interval report; if a
+task is cancelled, inspect `stats().last_report` and lifetime counters before
+deciding how to reconcile the covered rows.
+
+The default `AppendFailurePolicy::Stop` is strict: the first failed batch stops
+admission, and a successful barrier confirms that its accepted prefix committed.
+Use `max_in_flight_requests(1)` if request submission order matters; concurrent
+batches have no defined commit order.
+
+### Best-effort telemetry and logs
+
+Telemetry producers often cannot wait for admission or stop permanently after
+one unavailable batch. Opt into `Continue`, use `try_send()` on the hot path,
+and inspect settlement reports and lifetime stats.
+
+```rust
+use std::time::Duration;
+use scopedb_client::AppendDeliveryOutcome;
+use scopedb_client::AppendFailurePolicy;
+
+# async fn demo() -> Result<(), scopedb_client::Error> {
+# let client = scopedb_client::Client::new("http://127.0.0.1:6543", reqwest::Client::new())?;
+let telemetry = client
+    .table("events")
+    .append_stream()
+    .failure_policy(AppendFailurePolicy::Continue)
+    .flush_interval(Duration::from_secs(1))
+    .on_batch_failure(|event| eprintln!("append failure: {event:?}"))
+    .build()?;
+
+if let Err(error) = telemetry.try_send(&serde_json::json!({
+    "name": "request.completed",
+    "status": 200,
+})) {
+    // Send this diagnostic to a different sink.
+    eprintln!("telemetry row dropped locally: {error}");
+}
+
+let report = telemetry.shutdown().await?;
+if report.outcome != AppendDeliveryOutcome::Ok {
+    eprintln!("telemetry loss or ambiguity: {report:?}");
+}
+# Ok(())
+# }
+```
+
+`Ok(())` from `try_send()` still means local admission, not remote commit. It
+returns immediately with an error when serialization fails, the row is invalid
+or too large, the buffer is full, the circuit is open, or the stream is closed.
+Continue mode releases failed batches after accounting for them; it is not an
+in-memory retry queue.
+
+The circuit breaker rejects non-blocking `try_send()` calls while open. The
+backpressured `send()` path can still admit rows within the configured memory
+budget; their dispatch waits for the circuit probe, so use `try_send()` on
+latency-sensitive logging and telemetry paths.
+
+A continue-mode report classifies rows as committed, failed, unknown, or locally
+dropped. For accepted rows in a completed report:
+
+```text
+accepted_rows = committed_rows + failed_rows + unknown_rows
+```
+
+`AppendDeliveryOutcome::Partial` means at least one row committed while another
+row failed, was dropped, or remains unknown. With no committed rows, the outcome
+is `Unknown` when any batch may have committed and `Failed` otherwise. Only a
+loss-free report is `Ok`.
+
+The stream retries only the exact temporary HTTP batch explicitly reported as
+`Rejected`. A timeout, transport failure, or invalid success response is
+`Unknown` and is never automatically retried. An in-memory stream is not a
+durable queue; use an outbox when payloads must survive process failure or be
+available for reconciliation.
+
+### Choose a delivery path
+
+| Workload | Admission and delivery | Example |
+| --- | --- | --- |
+| One exact NDJSON payload | Caller owns the request boundary | [`append.rs`](examples/append.rs) |
+| Basic asynchronous batching | SDK owns batches; strict barriers | [`append_stream.rs`](examples/append_stream.rs) |
+| Backfill or file import | Bounded producer memory and concurrent strict batches | [`bulk_append.rs`](examples/bulk_append.rs) |
+| Long-running logs and events | Non-blocking continue mode with observable loss | [`telemetry.rs`](examples/telemetry.rs) |
+| SQL transformation before insert | Transform-oriented ingest stream | [`ingest_transform.rs`](examples/ingest_transform.rs) |
+
+## Table helper
 
 ```rust
 # async fn demo() -> Result<(), scopedb_client::Error> {
@@ -50,7 +282,11 @@ println!("fields = {}", schema.fields().len());
 # }
 ```
 
-## Batched JSON Ingest
+## Transform-oriented ingest
+
+`IngestStream` remains useful when input JSON needs a SQL transform before
+insertion. Prefer `Table::append` or `Table::append_stream` when records already
+match the destination table.
 
 ```rust
 # async fn demo() -> Result<(), scopedb_client::Error> {
@@ -59,9 +295,9 @@ let stream = client
     .ingest_stream(
         r#"
         SELECT
-            $0["ts"]::timestamp as ts,
+            $0["ts"]::timestamp as occurred_at,
             $0["name"]::string as name
-        INSERT INTO public.events (ts, name)
+        INSERT INTO public.events (occurred_at, name)
         "#,
     )
     .build();
@@ -69,24 +305,24 @@ let stream = client
 stream
     .send(&serde_json::json!({
         "ts": "2026-03-13T12:00:00Z",
-        "name": "scopedb",
+        "name": "ScopeDB",
     }))
     .await?;
-
-stream.flush().await?;
 stream.shutdown().await?;
 # Ok(())
 # }
 ```
 
-## Examples
+## Examples and development
 
-See runnable examples under [`examples/`](examples/):
+The [example guide](examples/README.md) includes setup, safety guards, delivery
+contracts, and runnable commands.
 
-- `cargo run --example statement`
-- `cargo run --example table`
-- `cargo run --example batch`
+```sh
+cargo check --examples
+cargo test
+cargo clippy --all-targets --all-features
+```
 
-## References
-
-- [Rust HTTP API reference](../docs/rust-http-api.md)
+The wire-level endpoint and payload reference is in
+[`docs/rust-http-api.md`](https://github.com/scopedb/scopedb-sdk/blob/main/docs/rust-http-api.md).

--- a/rust/examples/README.md
+++ b/rust/examples/README.md
@@ -1,0 +1,113 @@
+# ScopeDB Rust SDK examples
+
+Start with a quickstart, then choose a write pattern whose delivery tradeoffs
+match the workload. Every example uses only the public `scopedb-client` API.
+
+The commands below run from the [`rust/`](../) directory in a source checkout.
+
+## Read-only discovery
+
+These examples can run against a reachable ScopeDB endpoint without modifying
+data.
+
+| Example | Shows | Run |
+| --- | --- | --- |
+| [`statement.rs`](statement.rs) | Statement execution and typed result values | `cargo run --example statement` |
+| [`catalog.rs`](catalog.rs) | REST catalog pagination and full table metadata | `cargo run --example catalog` |
+| [`table.rs`](table.rs) | Quoted table identifiers and the table schema helper | `cargo run --example table` |
+
+## Before running a write example
+
+Every write example refuses to start unless `SCOPEDB_TABLE` names an existing,
+disposable table. Do not point these examples at production unless the writes
+are intentional.
+
+The append, stream, telemetry, and transform examples can share this schema:
+
+```sql
+CREATE TABLE public.sdk_example_events (
+  id int,
+  event_id string,
+  occurred_at timestamp,
+  name string,
+  attributes object
+);
+```
+
+Configuration comes from:
+
+- `SCOPEDB_ENDPOINT` (defaults to `http://127.0.0.1:6543`)
+- `SCOPEDB_TOKEN` (optional Bearer token)
+- `SCOPEDB_DATABASE` (defaults to `scopedb`)
+- `SCOPEDB_SCHEMA` (defaults to `public`)
+- `SCOPEDB_TABLE` (required for writes)
+
+Set the disposable destination once before running a write example:
+
+```sh
+export SCOPEDB_TABLE=sdk_example_events
+```
+
+```powershell
+$env:SCOPEDB_TABLE = "sdk_example_events"
+```
+
+## Choose a write journey
+
+| Example | Choose it when | Run |
+| --- | --- | --- |
+| [`append.rs`](append.rs) | The caller owns one exact NDJSON request boundary | `cargo run --example append` |
+| [`append_stream.rs`](append_stream.rs) | The SDK should asynchronously batch rows with strict delivery | `cargo run --example append_stream` |
+| [`bulk_append.rs`](bulk_append.rs) | A backfill needs bounded memory and concurrent strict batches | `cargo run --example bulk_append` |
+| [`telemetry.rs`](telemetry.rs) | Logs or events need non-blocking, observable best-effort delivery | `cargo run --example telemetry` |
+| [`ingest_transform.rs`](ingest_transform.rs) | JSON records need a SQL transform before insertion | `cargo run --example ingest_transform` |
+
+`append.rs` sends exactly one NDJSON request. `append_stream.rs` uses the
+default `Stop` policy: `send()` and `send_all()` wait only for local admission,
+while a successful `flush()` or `shutdown()` is a remote commit barrier for the
+accepted prefix.
+
+`bulk_append.rs` keeps producer memory bounded and sends multiple HTTP batches
+concurrently. It does not add durable resume, idempotency, transactionality, or
+whole-job rollback. Earlier concurrent batches may have committed even when a
+later batch fails.
+
+`telemetry.rs` opts into `AppendFailurePolicy::Continue` and uses `try_send()`
+on the request path. It keeps working after a failed batch, but does not retain
+the batch for replay. The shutdown report makes rejected, ambiguous, and local
+loss observable.
+
+When the continue-mode circuit is open, `try_send()` rejects immediately while
+the backpressured `send()` path can queue within the configured byte budget and
+wait for a later probe.
+
+## Delivery contract
+
+- The table append API accepts NDJSON only: one JSON row object per line,
+  not a JSON array.
+- `send()`, `send_all()`, and `Ok(())` from `try_send()` mean local admission;
+  they do not confirm a remote commit.
+- A successful strict barrier confirms that its accepted prefix committed.
+- A continue-mode barrier is settlement. Always inspect its
+  `AppendDeliveryReport`.
+- The stream retries only an exact temporary HTTP batch explicitly reported as
+  `rejected`.
+- A timeout, transport failure, or invalid success response is `unknown`. The
+  rows may already exist remotely, so never blindly replay that payload.
+- `shutdown()` closes admission and settles accepted rows. It is not an abort or
+  rollback; stop and join producer tasks before calling it.
+- Dropping an enqueued `flush()` future does not cancel its remote settlement;
+  keep the future alive to receive the interval report and use `stats()` for
+  post-cancellation diagnostics.
+- Concurrent batches do not have a defined commit order. Use
+  `max_in_flight_requests(1)` when requests must be submitted serially.
+- An in-memory stream is not a durable queue. Audit or billing writes need an
+  application-owned outbox and a reconciliation path for unknown outcomes.
+
+## Check the examples
+
+Compile every example without running it:
+
+```sh
+cargo check --examples
+```

--- a/rust/examples/append.rs
+++ b/rust/examples/append.rs
@@ -1,0 +1,61 @@
+// Copyright 2024 ScopeDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod common;
+
+use scopedb_client::AppendState;
+use scopedb_client::ErrorKind;
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = common::client()?;
+    let table = common::write_table(&client)?;
+
+    // Direct append sends exactly one caller-owned NDJSON request. Each value
+    // is serialized as one line; JSON arrays are not accepted by this API.
+    let ndjson = [
+        serde_json::json!({
+            "id": 1,
+            "occurred_at": jiff::Timestamp::now(),
+            "name": "first",
+        }),
+        serde_json::json!({
+            "id": 2,
+            "occurred_at": jiff::Timestamp::now(),
+            "name": "second",
+        }),
+    ]
+    .iter()
+    .map(serde_json::to_string)
+    .collect::<Result<Vec<_>, _>>()?
+    .join("\n");
+
+    match table.append(ndjson).await {
+        Ok(result) => {
+            println!("committed remotely: {} rows", result.num_rows_inserted);
+            Ok(())
+        }
+        Err(error) => {
+            if error.kind() == ErrorKind::AppendRowsFailed
+                && matches!(
+                    error.append_details().map(|details| details.append_state),
+                    Some(AppendState::Unknown)
+                )
+            {
+                eprintln!("commit outcome is unknown; reconcile before replaying this payload");
+            }
+            Err(error.into())
+        }
+    }
+}

--- a/rust/examples/append_stream.rs
+++ b/rust/examples/append_stream.rs
@@ -1,0 +1,45 @@
+// Copyright 2024 ScopeDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod common;
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = common::client()?;
+    let table = common::write_table(&client)?;
+    let stream = table.append_stream().build()?;
+
+    let admitted = stream
+        .send_all([
+            serde_json::json!({
+                "id": 1,
+                "occurred_at": jiff::Timestamp::now(),
+                "name": "first",
+            }),
+            serde_json::json!({
+                "id": 2,
+                "occurred_at": jiff::Timestamp::now(),
+                "name": "second",
+            }),
+        ])
+        .await?;
+    println!("accepted locally: {} rows", admitted.accepted_rows);
+
+    // send_all() confirms only local admission. With the default strict policy,
+    // successful shutdown is the remote commit barrier for that accepted prefix.
+    let report = stream.shutdown().await?;
+    println!("committed remotely: {} rows", report.committed_rows);
+
+    Ok(())
+}

--- a/rust/examples/bulk_append.rs
+++ b/rust/examples/bulk_append.rs
@@ -1,0 +1,82 @@
+// Copyright 2024 ScopeDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod common;
+
+use std::time::Duration;
+
+use scopedb_client::AppendState;
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = common::client()?;
+    let table = common::write_table(&client)?;
+
+    // The default Stop policy gives strict barriers. Local memory and request
+    // concurrency are bounded independently; concurrent batches have no
+    // defined commit order.
+    let stream = table
+        .append_stream()
+        .batch_bytes(32 * 1024)
+        .flush_interval(Duration::from_secs(1))
+        .max_pending_bytes(1024 * 1024)
+        .max_in_flight_requests(4)
+        .attempt_timeout(Duration::from_secs(30))
+        .build()?;
+
+    let rows = (1..=10_000).map(|id| {
+        serde_json::json!({
+            "id": id,
+            "occurred_at": jiff::Timestamp::now(),
+            "name": format!("example-{id}"),
+        })
+    });
+
+    let admission_error = match stream.send_all(rows).await {
+        Ok(result) => {
+            println!("accepted locally: {} rows", result.accepted_rows);
+            None
+        }
+        Err(error) => {
+            // There is no stream-wide abort or rollback. Settle the already
+            // accepted prefix even if row production or admission stopped.
+            eprintln!("row admission stopped; settling the accepted prefix: {error}");
+            Some(error)
+        }
+    };
+
+    match stream.shutdown().await {
+        Ok(report) => {
+            println!("committed remotely: {} rows", report.committed_rows);
+            println!("final stream stats: {:?}", stream.stats());
+        }
+        Err(error) => {
+            if matches!(
+                error.append_details().map(|details| details.append_state),
+                Some(AppendState::Unknown)
+            ) {
+                eprintln!("commit outcome is unknown; reconcile before replaying");
+            } else {
+                eprintln!("bulk append failed: {error}");
+            }
+            eprintln!("final stream stats: {:?}", stream.stats());
+            return Err(error.into());
+        }
+    }
+
+    if let Some(error) = admission_error {
+        return Err(error.into());
+    }
+    Ok(())
+}

--- a/rust/examples/catalog.rs
+++ b/rust/examples/catalog.rs
@@ -1,0 +1,69 @@
+// Copyright 2024 ScopeDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod common;
+
+use scopedb_client::CatalogListOptions;
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = common::client()?;
+    let database = common::database();
+    let schema = common::schema();
+
+    let mut page_token = None;
+    loop {
+        let page = client
+            .list_databases(CatalogListOptions {
+                page_size: Some(100),
+                page_token,
+            })
+            .await?;
+        for item in page.items {
+            println!(
+                "database {}: {}",
+                item.name,
+                item.comment.unwrap_or_default()
+            );
+        }
+        page_token = page.next_page_token;
+        if page_token.is_none() {
+            break;
+        }
+    }
+
+    let database_resource = client.fetch_database(&database).await?;
+    println!("selected database: {database_resource:?}");
+
+    let schemas = client
+        .list_schemas(&database, CatalogListOptions::default())
+        .await?;
+    for item in schemas.items {
+        println!("schema {}.{}", item.database, item.name);
+    }
+
+    let schema_resource = client.fetch_schema(&database, &schema).await?;
+    println!("selected schema: {schema_resource:?}");
+
+    let tables = client
+        .list_tables(&database, &schema, CatalogListOptions::default())
+        .await?;
+    if let Some(first) = tables.items.first() {
+        println!("first table summary: {first:?}");
+        let resource = client.fetch_table(&database, &schema, &first.name).await?;
+        println!("first table resource: {resource:?}");
+    }
+
+    Ok(())
+}

--- a/rust/examples/common/mod.rs
+++ b/rust/examples/common/mod.rs
@@ -12,12 +12,58 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(dead_code)]
+
+use std::io;
+
+use reqwest::header::AUTHORIZATION;
+use reqwest::header::HeaderMap;
+use reqwest::header::HeaderValue;
 use scopedb_client::Client;
+use scopedb_client::Table;
 
 pub fn endpoint() -> String {
     std::env::var("SCOPEDB_ENDPOINT").unwrap_or_else(|_| "http://127.0.0.1:6543".to_string())
 }
 
-pub fn client() -> Result<Client, scopedb_client::Error> {
-    Client::new(endpoint(), reqwest::Client::new())
+pub fn database() -> String {
+    std::env::var("SCOPEDB_DATABASE").unwrap_or_else(|_| "scopedb".to_string())
+}
+
+pub fn schema() -> String {
+    std::env::var("SCOPEDB_SCHEMA").unwrap_or_else(|_| "public".to_string())
+}
+
+pub fn client() -> Result<Client, Box<dyn std::error::Error>> {
+    let mut headers = HeaderMap::new();
+    if let Ok(token) = std::env::var("SCOPEDB_TOKEN") {
+        if !token.is_empty() {
+            headers.insert(
+                AUTHORIZATION,
+                HeaderValue::from_str(&format!("Bearer {token}"))?,
+            );
+        }
+    }
+
+    let http_client = reqwest::Client::builder()
+        .default_headers(headers)
+        .build()?;
+    Ok(Client::new(endpoint(), http_client)?)
+}
+
+pub fn write_table(client: &Client) -> Result<Table, io::Error> {
+    let table = std::env::var("SCOPEDB_TABLE")
+        .ok()
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "set SCOPEDB_TABLE to a disposable table before running this write example",
+            )
+        })?;
+
+    Ok(client
+        .table(table)
+        .with_database(database())
+        .with_schema(schema()))
 }

--- a/rust/examples/ingest_transform.rs
+++ b/rust/examples/ingest_transform.rs
@@ -19,33 +19,29 @@ use std::time::Duration;
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let client = common::client()?;
+    let target = common::write_table(&client)?;
 
+    // Prefer Table::append or Table::append_stream when records already have
+    // the target shape. IngestStream is useful when each record needs a SQL
+    // transformation before insertion.
     let stream = client
-        .ingest_stream(
+        .ingest_stream(format!(
             r#"
             SELECT
-                $0["ts"]::timestamp as ts,
-                $0["name"]::string as name,
-                $0
-            INSERT INTO public.events (ts, name, raw)
+                $0["ts"]::timestamp as occurred_at,
+                $0["name"]::string as name
+            INSERT INTO {} (occurred_at, name)
             "#,
-        )
-        .batch_bytes(1024)
+            target.identifier()
+        ))
+        .batch_bytes(1024 * 1024)
         .flush_interval(Duration::from_millis(250))
         .build();
 
     stream
         .send(&serde_json::json!({
             "ts": "2026-03-13T12:00:00Z",
-            "name": "alpha",
-            "extra": {"source": "example"},
-        }))
-        .await?;
-    stream
-        .send(&serde_json::json!({
-            "ts": "2026-03-13T12:00:01Z",
-            "name": "beta",
-            "extra": {"source": "example"},
+            "name": "ScopeDB",
         }))
         .await?;
 

--- a/rust/examples/table.rs
+++ b/rust/examples/table.rs
@@ -17,7 +17,11 @@ mod common;
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let client = common::client()?;
-    let table = client.table("events").with_schema("public");
+    let table_name = std::env::var("SCOPEDB_TABLE").unwrap_or_else(|_| "events".to_string());
+    let table = client
+        .table(table_name)
+        .with_database(common::database())
+        .with_schema(common::schema());
 
     println!("identifier: {}", table.identifier());
 

--- a/rust/examples/telemetry.rs
+++ b/rust/examples/telemetry.rs
@@ -1,0 +1,78 @@
+// Copyright 2024 ScopeDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod common;
+
+use std::time::Duration;
+
+use scopedb_client::AppendDeliveryOutcome;
+use scopedb_client::AppendFailurePolicy;
+use scopedb_client::AppendStream;
+use uuid::Uuid;
+
+fn track(stream: &AppendStream, request: u64) -> bool {
+    match stream.try_send(&serde_json::json!({
+        "event_id": Uuid::now_v7(),
+        "occurred_at": jiff::Timestamp::now(),
+        "name": "request.completed",
+        "attributes": {"request": request, "status": 200},
+    })) {
+        // This means local admission only, not a remote commit.
+        Ok(()) => true,
+        Err(error) => {
+            // Route this diagnostic to another sink, never back into `stream`.
+            eprintln!("telemetry row dropped locally: {error}");
+            false
+        }
+    }
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = common::client()?;
+    let table = common::write_table(&client)?;
+
+    // Continue mode is explicitly best effort: failed or ambiguous batches are
+    // accounted for, released, and do not stop later telemetry batches.
+    let telemetry = table
+        .append_stream()
+        .failure_policy(AppendFailurePolicy::Continue)
+        .batch_bytes(1024 * 1024)
+        .flush_interval(Duration::from_secs(1))
+        .max_pending_bytes(32 * 1024 * 1024)
+        .max_in_flight_requests(2)
+        .attempt_timeout(Duration::from_secs(10))
+        .on_batch_failure(|event| {
+            // A synchronous observer; use a separate diagnostics sink.
+            eprintln!("telemetry append failure: {event:?}");
+        })
+        .build()?;
+
+    let mut dropped_locally = 0_u64;
+    for request in 1..=100 {
+        if !track(&telemetry, request) {
+            dropped_locally += 1;
+        }
+    }
+    println!("locally dropped: {dropped_locally}");
+
+    // In a service, stop and join producer tasks before this settlement barrier.
+    let report = telemetry.shutdown().await?;
+    if report.outcome != AppendDeliveryOutcome::Ok {
+        eprintln!("telemetry loss or ambiguity: {report:?}");
+    }
+    println!("final stream stats: {:?}", telemetry.stats());
+
+    Ok(())
+}

--- a/rust/src/append_stream.rs
+++ b/rust/src/append_stream.rs
@@ -1,0 +1,2430 @@
+// Copyright 2024 ScopeDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::error::Error as StdError;
+use std::fmt;
+use std::panic::AssertUnwindSafe;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::sync::MutexGuard;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
+use std::time::Duration;
+use std::time::Instant;
+use std::time::SystemTime;
+
+use serde::Serialize;
+use tokio::sync::Notify;
+use tokio::sync::OwnedSemaphorePermit;
+use tokio::sync::Semaphore;
+use tokio::sync::mpsc;
+use tokio::sync::oneshot;
+use tokio::task::JoinHandle;
+use tokio::task::JoinSet;
+
+use crate::AppendErrorDetails;
+use crate::AppendRowsResult;
+use crate::AppendState;
+use crate::Client;
+use crate::Error;
+use crate::ErrorKind;
+
+const MAX_APPEND_BODY_BYTES: usize = 16 * 1024 * 1024;
+const MAX_APPEND_ROWS: usize = 200_000;
+const DEFAULT_BATCH_BYTES: usize = MAX_APPEND_BODY_BYTES;
+const DEFAULT_FLUSH_INTERVAL: Duration = Duration::from_secs(1);
+const DEFAULT_CHANNEL_CAPACITY: usize = 1024;
+const DEFAULT_MAX_IN_FLIGHT_REQUESTS: usize = 4;
+const DEFAULT_MAX_PENDING_BYTES: usize = DEFAULT_BATCH_BYTES * DEFAULT_MAX_IN_FLIGHT_REQUESTS;
+const DEFAULT_MAX_RETRIES: usize = 8;
+const DEFAULT_INITIAL_BACKOFF: Duration = Duration::from_millis(100);
+const DEFAULT_MAX_BACKOFF: Duration = Duration::from_secs(5);
+const DEFAULT_CONTINUE_ATTEMPT_TIMEOUT: Duration = Duration::from_secs(30);
+const DEFAULT_CIRCUIT_FAILURE_THRESHOLD: usize = 5;
+const DEFAULT_CIRCUIT_COOLDOWN: Duration = Duration::from_secs(30);
+
+/// Determines what an append stream does after one HTTP batch fails.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum AppendFailurePolicy {
+    /// Stop accepting rows and fail the stream's delivery barrier.
+    #[default]
+    Stop,
+    /// Record the loss in the delivery report and continue with later batches.
+    Continue,
+}
+
+/// The lifecycle state of an append stream.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum AppendStreamState {
+    Open,
+    Closing,
+    Closed,
+    Failed,
+}
+
+/// The state of the continue-mode availability circuit breaker.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum AppendCircuitState {
+    Closed,
+    Open,
+    HalfOpen,
+}
+
+/// The aggregate result of a delivery barrier.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum AppendDeliveryOutcome {
+    /// Every covered row was committed and no local rows were dropped.
+    Ok,
+    /// Some covered rows committed and some were lost or have an unknown outcome.
+    Partial,
+    /// No covered row committed and all losses are known not to have committed.
+    Failed,
+    /// No covered row is known to have committed and at least one may have committed.
+    Unknown,
+}
+
+/// Rows accepted by a bulk local-admission operation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AppendAdmissionResult {
+    pub accepted_rows: u64,
+}
+
+/// Aggregate settlement information since the previous delivery barrier.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AppendDeliveryReport {
+    pub outcome: AppendDeliveryOutcome,
+    pub accepted_rows: u64,
+    pub committed_rows: u64,
+    pub failed_rows: u64,
+    pub unknown_rows: u64,
+    pub dropped_rows: u64,
+    pub committed_batches: u64,
+    pub failed_batches: u64,
+    pub unknown_batches: u64,
+    pub retries: u64,
+    /// Wall time spent waiting for this barrier.
+    pub duration: Duration,
+}
+
+/// Local drop counters grouped by admission failure reason.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct AppendDroppedRows {
+    pub buffer_full: u64,
+    pub invalid_record: u64,
+    pub record_too_large: u64,
+    pub circuit_open: u64,
+    pub closed: u64,
+}
+
+/// The most recent remote append failure observed by the stream.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AppendLastFailure {
+    pub at: SystemTime,
+    pub message: String,
+    pub append_state: Option<AppendState>,
+}
+
+/// A point-in-time snapshot of append stream counters and state.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AppendStreamStats {
+    pub state: AppendStreamState,
+    pub circuit_state: AppendCircuitState,
+    pub accepted_rows: u64,
+    pub committed_rows: u64,
+    pub failed_rows: u64,
+    pub unknown_rows: u64,
+    pub dropped_rows: u64,
+    pub dropped_by_reason: AppendDroppedRows,
+    pub retries: u64,
+    pub pending_rows: u64,
+    pub pending_bytes: usize,
+    pub in_flight_batches: usize,
+    pub last_failure: Option<AppendLastFailure>,
+    pub last_report: Option<AppendDeliveryReport>,
+}
+
+/// Action taken after a batch failure listener is invoked.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum AppendBatchFailureAction {
+    Continuing,
+    CircuitOpened,
+    Stopped,
+}
+
+/// Diagnostic event emitted after a rejected or ambiguous append batch.
+pub struct AppendBatchFailureEvent {
+    pub error: Error,
+    pub batch_rows: usize,
+    pub batch_bytes: usize,
+    pub outcome: AppendState,
+    pub action: AppendBatchFailureAction,
+}
+
+impl fmt::Debug for AppendBatchFailureEvent {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("AppendBatchFailureEvent")
+            .field("error", &self.error)
+            .field("batch_rows", &self.batch_rows)
+            .field("batch_bytes", &self.batch_bytes)
+            .field("outcome", &self.outcome)
+            .field("action", &self.action)
+            .finish()
+    }
+}
+
+/// Continue-mode circuit breaker settings.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct AppendCircuitBreakerOptions {
+    pub failure_threshold: usize,
+    pub cooldown: Duration,
+}
+
+impl AppendCircuitBreakerOptions {
+    pub fn new(failure_threshold: usize, cooldown: Duration) -> Self {
+        Self {
+            failure_threshold,
+            cooldown,
+        }
+    }
+}
+
+impl Default for AppendCircuitBreakerOptions {
+    fn default() -> Self {
+        Self::new(DEFAULT_CIRCUIT_FAILURE_THRESHOLD, DEFAULT_CIRCUIT_COOLDOWN)
+    }
+}
+
+/// A synchronous local-admission failure from [`AppendStream::try_send`].
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum AppendTrySendError {
+    Serialization(serde_json::Error),
+    InvalidRecord,
+    RecordTooLarge { bytes: usize, limit: usize },
+    BufferFull,
+    CircuitOpen,
+    Closed,
+}
+
+impl fmt::Display for AppendTrySendError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Serialization(err) => write!(f, "failed to serialize append row: {err}"),
+            Self::InvalidRecord => write!(f, "append row must serialize to a JSON object"),
+            Self::RecordTooLarge { bytes, limit } => {
+                write!(
+                    f,
+                    "append row is {bytes} bytes, exceeding the {limit}-byte limit"
+                )
+            }
+            Self::BufferFull => write!(f, "append stream local buffer is full"),
+            Self::CircuitOpen => write!(f, "append stream circuit breaker is open"),
+            Self::Closed => write!(f, "append stream is closed"),
+        }
+    }
+}
+
+impl StdError for AppendTrySendError {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        match self {
+            Self::Serialization(err) => Some(err),
+            _ => None,
+        }
+    }
+}
+
+type BatchFailureListener = Arc<dyn Fn(&AppendBatchFailureEvent) + Send + Sync>;
+
+#[derive(Debug, Clone, Copy)]
+struct RetryConfig {
+    max_retries: usize,
+    initial_backoff: Duration,
+    max_backoff: Duration,
+}
+
+/// Configures a bounded, concurrent table append stream.
+pub struct AppendStreamBuilder {
+    client: Client,
+    database: String,
+    schema: String,
+    table: String,
+    batch_bytes: usize,
+    flush_interval: Duration,
+    channel_capacity: usize,
+    max_pending_bytes: usize,
+    max_in_flight_requests: usize,
+    retry: RetryConfig,
+    failure_policy: AppendFailurePolicy,
+    attempt_timeout: Option<Duration>,
+    circuit_breaker: Option<AppendCircuitBreakerOptions>,
+    batch_failure_listeners: Vec<BatchFailureListener>,
+}
+
+impl AppendStreamBuilder {
+    pub(crate) fn new(client: Client, database: String, schema: String, table: String) -> Self {
+        Self {
+            client,
+            database,
+            schema,
+            table,
+            batch_bytes: DEFAULT_BATCH_BYTES,
+            flush_interval: DEFAULT_FLUSH_INTERVAL,
+            channel_capacity: DEFAULT_CHANNEL_CAPACITY,
+            max_pending_bytes: DEFAULT_MAX_PENDING_BYTES,
+            max_in_flight_requests: DEFAULT_MAX_IN_FLIGHT_REQUESTS,
+            retry: RetryConfig {
+                max_retries: DEFAULT_MAX_RETRIES,
+                initial_backoff: DEFAULT_INITIAL_BACKOFF,
+                max_backoff: DEFAULT_MAX_BACKOFF,
+            },
+            failure_policy: AppendFailurePolicy::Stop,
+            attempt_timeout: None,
+            circuit_breaker: Some(AppendCircuitBreakerOptions::default()),
+            batch_failure_listeners: Vec::new(),
+        }
+    }
+
+    pub fn failure_policy(mut self, failure_policy: AppendFailurePolicy) -> Self {
+        self.failure_policy = failure_policy;
+        self
+    }
+
+    /// Sets the target NDJSON payload size. One row may exceed this target up to 16 MiB.
+    pub fn batch_bytes(mut self, batch_bytes: usize) -> Self {
+        self.batch_bytes = batch_bytes;
+        self
+    }
+
+    /// Sets the maximum delay between buffering the first row and dispatching its batch.
+    pub fn flush_interval(mut self, flush_interval: Duration) -> Self {
+        self.flush_interval = flush_interval;
+        self
+    }
+
+    pub fn channel_capacity(mut self, channel_capacity: usize) -> Self {
+        self.channel_capacity = channel_capacity;
+        self
+    }
+
+    pub fn max_pending_bytes(mut self, max_pending_bytes: usize) -> Self {
+        self.max_pending_bytes = max_pending_bytes;
+        self
+    }
+
+    /// Sets the maximum number of append HTTP requests running concurrently.
+    pub fn max_in_flight_requests(mut self, max_in_flight_requests: usize) -> Self {
+        self.max_in_flight_requests = max_in_flight_requests;
+        self
+    }
+
+    pub fn max_retries(mut self, max_retries: usize) -> Self {
+        self.retry.max_retries = max_retries;
+        self
+    }
+
+    pub fn initial_backoff(mut self, initial_backoff: Duration) -> Self {
+        self.retry.initial_backoff = initial_backoff;
+        self
+    }
+
+    pub fn max_backoff(mut self, max_backoff: Duration) -> Self {
+        self.retry.max_backoff = max_backoff;
+        self
+    }
+
+    /// Sets a timeout for each HTTP attempt. A timeout has an unknown commit outcome.
+    pub fn attempt_timeout(mut self, attempt_timeout: Duration) -> Self {
+        self.attempt_timeout = Some(attempt_timeout);
+        self
+    }
+
+    /// Configures the continue-mode availability circuit, or disables it with `None`.
+    pub fn circuit_breaker(mut self, circuit_breaker: Option<AppendCircuitBreakerOptions>) -> Self {
+        self.circuit_breaker = circuit_breaker;
+        self
+    }
+
+    /// Observes remote batch failures. Listener panics are isolated from the worker.
+    pub fn on_batch_failure<F>(mut self, listener: F) -> Self
+    where
+        F: Fn(&AppendBatchFailureEvent) + Send + Sync + 'static,
+    {
+        self.batch_failure_listeners.push(Arc::new(listener));
+        self
+    }
+
+    pub fn build(self) -> Result<AppendStream, Error> {
+        validate_builder(&self)?;
+        tokio::runtime::Handle::try_current().map_err(|err| {
+            Error::new(
+                ErrorKind::ConfigInvalid,
+                "append stream must be built inside a Tokio runtime",
+            )
+            .set_source(err)
+        })?;
+
+        let attempt_timeout = self.attempt_timeout.or_else(|| {
+            (self.failure_policy == AppendFailurePolicy::Continue)
+                .then_some(DEFAULT_CONTINUE_ATTEMPT_TIMEOUT)
+        });
+        Ok(AppendStream::new(AppendStreamConfig {
+            client: self.client,
+            database: self.database,
+            schema: self.schema,
+            table: self.table,
+            batch_bytes: self.batch_bytes,
+            flush_interval: self.flush_interval,
+            channel_capacity: self.channel_capacity,
+            max_pending_bytes: self.max_pending_bytes,
+            max_in_flight_requests: self.max_in_flight_requests,
+            retry: self.retry,
+            failure_policy: self.failure_policy,
+            attempt_timeout,
+            circuit_breaker: self.circuit_breaker,
+            batch_failure_listeners: self.batch_failure_listeners,
+        }))
+    }
+}
+
+fn validate_builder(builder: &AppendStreamBuilder) -> Result<(), Error> {
+    validate_positive("batch_bytes", builder.batch_bytes)?;
+    if builder.batch_bytes > MAX_APPEND_BODY_BYTES {
+        return Err(config_error(format!(
+            "batch_bytes must not exceed {MAX_APPEND_BODY_BYTES}"
+        )));
+    }
+    if builder.flush_interval.is_zero() {
+        return Err(config_error("flush_interval must be greater than zero"));
+    }
+    validate_deadline("flush_interval", builder.flush_interval)?;
+    validate_positive("channel_capacity", builder.channel_capacity)?;
+    validate_positive("max_pending_bytes", builder.max_pending_bytes)?;
+    if builder.max_pending_bytes > u32::MAX as usize {
+        return Err(config_error(format!(
+            "max_pending_bytes must not exceed {}",
+            u32::MAX
+        )));
+    }
+    validate_positive("max_in_flight_requests", builder.max_in_flight_requests)?;
+    if builder
+        .attempt_timeout
+        .is_some_and(|attempt_timeout| attempt_timeout.is_zero())
+    {
+        return Err(config_error("attempt_timeout must be greater than zero"));
+    }
+    if let Some(attempt_timeout) = builder.attempt_timeout {
+        validate_deadline("attempt_timeout", attempt_timeout)?;
+    }
+    if let Some(circuit) = builder.circuit_breaker {
+        validate_positive(
+            "circuit_breaker.failure_threshold",
+            circuit.failure_threshold,
+        )?;
+        if circuit.cooldown.is_zero() {
+            return Err(config_error(
+                "circuit_breaker.cooldown must be greater than zero",
+            ));
+        }
+        validate_deadline("circuit_breaker.cooldown", circuit.cooldown)?;
+    }
+    Ok(())
+}
+
+fn validate_deadline(name: &str, duration: Duration) -> Result<(), Error> {
+    if Instant::now().checked_add(duration).is_none() {
+        Err(config_error(format!("{name} is too large")))
+    } else {
+        Ok(())
+    }
+}
+
+fn validate_positive(name: &str, value: usize) -> Result<(), Error> {
+    if value == 0 {
+        Err(config_error(format!("{name} must be greater than zero")))
+    } else {
+        Ok(())
+    }
+}
+
+fn config_error(message: impl Into<String>) -> Error {
+    Error::new(ErrorKind::ConfigInvalid, message)
+}
+
+struct AppendStreamConfig {
+    client: Client,
+    database: String,
+    schema: String,
+    table: String,
+    batch_bytes: usize,
+    flush_interval: Duration,
+    channel_capacity: usize,
+    max_pending_bytes: usize,
+    max_in_flight_requests: usize,
+    retry: RetryConfig,
+    failure_policy: AppendFailurePolicy,
+    attempt_timeout: Option<Duration>,
+    circuit_breaker: Option<AppendCircuitBreakerOptions>,
+    batch_failure_listeners: Vec<BatchFailureListener>,
+}
+
+enum AppendCommand {
+    Record(BufferedRecord),
+    Flush(BarrierCommand),
+    Shutdown(BarrierCommand),
+}
+
+struct BarrierCommand {
+    dropped_rows_at_barrier: u64,
+    started_at: Instant,
+    ack: oneshot::Sender<Result<AppendDeliveryReport, Error>>,
+}
+
+struct BufferedRecord {
+    payload: String,
+    reserved_bytes: usize,
+    _reservation: OwnedSemaphorePermit,
+}
+
+struct PendingBytesBudget {
+    capacity: usize,
+    semaphore: Arc<Semaphore>,
+    closed: AtomicBool,
+}
+
+impl PendingBytesBudget {
+    fn new(capacity: usize) -> Self {
+        Self {
+            capacity,
+            semaphore: Arc::new(Semaphore::new(capacity)),
+            closed: AtomicBool::new(false),
+        }
+    }
+
+    async fn acquire(&self, bytes: usize) -> Result<OwnedSemaphorePermit, PendingAcquireError> {
+        if bytes > self.capacity {
+            return Err(PendingAcquireError::ExceedsCapacity);
+        }
+        if self.closed.load(Ordering::Acquire) {
+            return Err(PendingAcquireError::Closed);
+        }
+        let permit = self
+            .semaphore
+            .clone()
+            .acquire_many_owned(bytes as u32)
+            .await
+            .map_err(|_| PendingAcquireError::Closed)?;
+        if self.closed.load(Ordering::Acquire) {
+            drop(permit);
+            return Err(PendingAcquireError::Closed);
+        }
+        Ok(permit)
+    }
+
+    fn try_acquire(&self, bytes: usize) -> Result<OwnedSemaphorePermit, PendingAcquireError> {
+        if bytes > self.capacity {
+            return Err(PendingAcquireError::ExceedsCapacity);
+        }
+        if self.closed.load(Ordering::Acquire) {
+            return Err(PendingAcquireError::Closed);
+        }
+        self.semaphore
+            .clone()
+            .try_acquire_many_owned(bytes as u32)
+            .map_err(|err| match err {
+                tokio::sync::TryAcquireError::Closed => PendingAcquireError::Closed,
+                tokio::sync::TryAcquireError::NoPermits => PendingAcquireError::Full,
+            })
+    }
+
+    fn close(&self) {
+        self.closed.store(true, Ordering::Release);
+        self.semaphore.close();
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PendingAcquireError {
+    Closed,
+    Full,
+    ExceedsCapacity,
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+struct DeliveryCounters {
+    accepted_rows: u64,
+    committed_rows: u64,
+    failed_rows: u64,
+    unknown_rows: u64,
+    committed_batches: u64,
+    failed_batches: u64,
+    unknown_batches: u64,
+    retries: u64,
+}
+
+struct CircuitRuntime {
+    state: AppendCircuitState,
+    opened_until: Option<Instant>,
+    consecutive_failures: usize,
+    probe_admission_claimed: bool,
+}
+
+impl Default for CircuitRuntime {
+    fn default() -> Self {
+        Self {
+            state: AppendCircuitState::Closed,
+            opened_until: None,
+            consecutive_failures: 0,
+            probe_admission_claimed: false,
+        }
+    }
+}
+
+struct SharedState {
+    lifecycle: AppendStreamState,
+    fatal: Option<StreamErrorSnapshot>,
+    final_result: Option<Result<AppendDeliveryReport, StreamErrorSnapshot>>,
+    accepted_rows: u64,
+    committed_rows: u64,
+    failed_rows: u64,
+    unknown_rows: u64,
+    dropped_rows: u64,
+    dropped_by_reason: AppendDroppedRows,
+    retries: u64,
+    pending_rows: u64,
+    pending_bytes: usize,
+    in_flight_batches: usize,
+    last_failure: Option<AppendLastFailure>,
+    last_report: Option<AppendDeliveryReport>,
+    circuit: CircuitRuntime,
+}
+
+impl Default for SharedState {
+    fn default() -> Self {
+        Self {
+            lifecycle: AppendStreamState::Open,
+            fatal: None,
+            final_result: None,
+            accepted_rows: 0,
+            committed_rows: 0,
+            failed_rows: 0,
+            unknown_rows: 0,
+            dropped_rows: 0,
+            dropped_by_reason: AppendDroppedRows::default(),
+            retries: 0,
+            pending_rows: 0,
+            pending_bytes: 0,
+            in_flight_batches: 0,
+            last_failure: None,
+            last_report: None,
+            circuit: CircuitRuntime::default(),
+        }
+    }
+}
+
+struct AppendStreamInner {
+    tx: mpsc::Sender<AppendCommand>,
+    shared: Arc<Mutex<SharedState>>,
+    pending_bytes: Arc<PendingBytesBudget>,
+    shutdown_notify: Arc<Notify>,
+}
+
+/// A cloneable, bounded producer handle for asynchronous table appends.
+#[derive(Clone)]
+pub struct AppendStream {
+    inner: Arc<AppendStreamInner>,
+}
+
+impl AppendStream {
+    fn new(config: AppendStreamConfig) -> Self {
+        let (tx, rx) = mpsc::channel(config.channel_capacity);
+        let shared = Arc::new(Mutex::new(SharedState::default()));
+        let pending_bytes = Arc::new(PendingBytesBudget::new(config.max_pending_bytes));
+        let shutdown_notify = Arc::new(Notify::new());
+
+        let worker = tokio::spawn(run_append_worker(
+            config,
+            rx,
+            shared.clone(),
+            pending_bytes.clone(),
+            shutdown_notify.clone(),
+        ));
+        tokio::spawn(monitor_append_worker(
+            worker,
+            shared.clone(),
+            pending_bytes.clone(),
+            shutdown_notify.clone(),
+        ));
+
+        Self {
+            inner: Arc::new(AppendStreamInner {
+                tx,
+                shared,
+                pending_bytes,
+                shutdown_notify,
+            }),
+        }
+    }
+
+    /// Serializes and admits one row, waiting for bounded local capacity.
+    ///
+    /// Success means local admission only. Use [`Self::flush`] or
+    /// [`Self::shutdown`] to wait for remote settlement.
+    pub async fn send<T>(&self, row: &T) -> Result<(), Error>
+    where
+        T: Serialize + ?Sized,
+    {
+        self.check_open()?;
+        let payload = prepare_record(row)?;
+        let reserved_bytes = payload.len().saturating_add(1);
+        let reservation = self
+            .inner
+            .pending_bytes
+            .acquire(reserved_bytes)
+            .await
+            .map_err(|err| self.map_pending_error(err, reserved_bytes))?;
+        let permit = match self.inner.tx.reserve().await {
+            Ok(permit) => permit,
+            Err(_) => {
+                drop(reservation);
+                return Err(self.closed_or_fatal_error());
+            }
+        };
+
+        let mut shared = lock(&self.inner.shared);
+        if shared.lifecycle != AppendStreamState::Open {
+            drop(shared);
+            drop(permit);
+            drop(reservation);
+            return Err(self.closed_or_fatal_error());
+        }
+        shared.accepted_rows = shared.accepted_rows.saturating_add(1);
+        shared.pending_rows = shared.pending_rows.saturating_add(1);
+        shared.pending_bytes = shared.pending_bytes.saturating_add(reserved_bytes);
+        permit.send(AppendCommand::Record(BufferedRecord {
+            payload,
+            reserved_bytes,
+            _reservation: reservation,
+        }));
+        Ok(())
+    }
+
+    /// Attempts synchronous local admission without waiting for capacity.
+    pub fn try_send<T>(&self, row: &T) -> Result<(), AppendTrySendError>
+    where
+        T: Serialize + ?Sized,
+    {
+        {
+            let shared = lock(&self.inner.shared);
+            if shared.lifecycle != AppendStreamState::Open {
+                drop(shared);
+                note_drop(&mut lock(&self.inner.shared), DropReason::Closed);
+                return Err(AppendTrySendError::Closed);
+            }
+            if !circuit_admission_available(&shared) {
+                drop(shared);
+                note_drop(&mut lock(&self.inner.shared), DropReason::CircuitOpen);
+                return Err(AppendTrySendError::CircuitOpen);
+            }
+        }
+
+        let payload = match prepare_record_for_try_send(row) {
+            Ok(payload) => payload,
+            Err(err) => {
+                let reason = match err {
+                    AppendTrySendError::RecordTooLarge { .. } => DropReason::RecordTooLarge,
+                    _ => DropReason::InvalidRecord,
+                };
+                note_drop(&mut lock(&self.inner.shared), reason);
+                return Err(err);
+            }
+        };
+        let reserved_bytes = payload.len().saturating_add(1);
+        let reservation = match self.inner.pending_bytes.try_acquire(reserved_bytes) {
+            Ok(reservation) => reservation,
+            Err(PendingAcquireError::Closed) => {
+                note_drop(&mut lock(&self.inner.shared), DropReason::Closed);
+                return Err(AppendTrySendError::Closed);
+            }
+            Err(PendingAcquireError::Full | PendingAcquireError::ExceedsCapacity) => {
+                note_drop(&mut lock(&self.inner.shared), DropReason::BufferFull);
+                return Err(AppendTrySendError::BufferFull);
+            }
+        };
+        let permit = match self.inner.tx.try_reserve() {
+            Ok(permit) => permit,
+            Err(mpsc::error::TrySendError::Full(_)) => {
+                drop(reservation);
+                note_drop(&mut lock(&self.inner.shared), DropReason::BufferFull);
+                return Err(AppendTrySendError::BufferFull);
+            }
+            Err(mpsc::error::TrySendError::Closed(_)) => {
+                drop(reservation);
+                note_drop(&mut lock(&self.inner.shared), DropReason::Closed);
+                return Err(AppendTrySendError::Closed);
+            }
+        };
+
+        let mut shared = lock(&self.inner.shared);
+        if shared.lifecycle != AppendStreamState::Open {
+            drop(shared);
+            drop(permit);
+            drop(reservation);
+            note_drop(&mut lock(&self.inner.shared), DropReason::Closed);
+            return Err(AppendTrySendError::Closed);
+        }
+        if !try_claim_circuit_admission(&mut shared) {
+            drop(shared);
+            drop(permit);
+            drop(reservation);
+            note_drop(&mut lock(&self.inner.shared), DropReason::CircuitOpen);
+            return Err(AppendTrySendError::CircuitOpen);
+        }
+        shared.accepted_rows = shared.accepted_rows.saturating_add(1);
+        shared.pending_rows = shared.pending_rows.saturating_add(1);
+        shared.pending_bytes = shared.pending_bytes.saturating_add(reserved_bytes);
+        permit.send(AppendCommand::Record(BufferedRecord {
+            payload,
+            reserved_bytes,
+            _reservation: reservation,
+        }));
+        Ok(())
+    }
+
+    /// Admits an iterator of rows sequentially with bounded memory.
+    pub async fn send_all<I>(&self, rows: I) -> Result<AppendAdmissionResult, Error>
+    where
+        I: IntoIterator,
+        I::Item: Serialize,
+    {
+        let mut accepted_rows = 0u64;
+        for row in rows {
+            self.send(&row).await?;
+            accepted_rows = accepted_rows.saturating_add(1);
+        }
+        Ok(AppendAdmissionResult { accepted_rows })
+    }
+
+    /// Dispatches rows admitted before this barrier and waits for their outcomes.
+    ///
+    /// Once enqueued, dropping this future does not cancel remote settlement.
+    /// Keep the future alive to receive its interval report; the latest completed
+    /// report also remains observable through [`Self::stats`].
+    pub async fn flush(&self) -> Result<AppendDeliveryReport, Error> {
+        loop {
+            let notified = self.inner.shutdown_notify.notified();
+            match self.current_terminal_result() {
+                TerminalResult::Open => {}
+                TerminalResult::Waiting => {
+                    notified.await;
+                    continue;
+                }
+                TerminalResult::Complete(result) => return result,
+            }
+
+            let permit = match self.inner.tx.reserve().await {
+                Ok(permit) => permit,
+                Err(_) => return self.wait_for_terminal().await,
+            };
+            let (ack, response) = oneshot::channel();
+            {
+                let shared = lock(&self.inner.shared);
+                if shared.lifecycle != AppendStreamState::Open {
+                    drop(shared);
+                    drop(permit);
+                    continue;
+                }
+                permit.send(AppendCommand::Flush(BarrierCommand {
+                    dropped_rows_at_barrier: shared.dropped_rows,
+                    started_at: Instant::now(),
+                    ack,
+                }));
+            }
+            return match response.await {
+                Ok(result) => result,
+                Err(_) => self.wait_for_terminal().await,
+            };
+        }
+    }
+
+    /// Permanently closes the stream after settling every admitted row.
+    ///
+    /// This method is idempotent across cloned producer handles.
+    pub async fn shutdown(&self) -> Result<AppendDeliveryReport, Error> {
+        let should_start = {
+            let mut shared = lock(&self.inner.shared);
+            match shared.lifecycle {
+                AppendStreamState::Open => {
+                    shared.lifecycle = AppendStreamState::Closing;
+                    true
+                }
+                AppendStreamState::Closing | AppendStreamState::Failed => false,
+                AppendStreamState::Closed if shared.final_result.is_some() => {
+                    return terminal_result(&shared);
+                }
+                AppendStreamState::Closed => false,
+            }
+        };
+
+        if should_start {
+            let inner = self.inner.clone();
+            tokio::spawn(async move {
+                let result = enqueue_shutdown(inner.clone()).await;
+                let mut shared = lock(&inner.shared);
+                if shared.final_result.is_none() {
+                    match &result {
+                        Ok(report) => {
+                            shared.lifecycle = AppendStreamState::Closed;
+                            shared.last_report = Some(report.clone());
+                            shared.final_result = Some(Ok(report.clone()));
+                        }
+                        Err(error) => {
+                            let snapshot = StreamErrorSnapshot::from_error(error);
+                            shared.lifecycle = AppendStreamState::Failed;
+                            shared.fatal = Some(snapshot.clone());
+                            shared.final_result = Some(Err(snapshot));
+                        }
+                    }
+                }
+                drop(shared);
+                inner.pending_bytes.close();
+                inner.shutdown_notify.notify_waiters();
+            });
+        }
+
+        self.wait_for_terminal().await
+    }
+
+    /// Returns a synchronous snapshot suitable for metrics and shutdown diagnostics.
+    pub fn stats(&self) -> AppendStreamStats {
+        let shared = lock(&self.inner.shared);
+        AppendStreamStats {
+            state: shared.lifecycle,
+            circuit_state: shared.circuit.state,
+            accepted_rows: shared.accepted_rows,
+            committed_rows: shared.committed_rows,
+            failed_rows: shared.failed_rows,
+            unknown_rows: shared.unknown_rows,
+            dropped_rows: shared.dropped_rows,
+            dropped_by_reason: shared.dropped_by_reason,
+            retries: shared.retries,
+            pending_rows: shared.pending_rows,
+            pending_bytes: shared.pending_bytes,
+            in_flight_batches: shared.in_flight_batches,
+            last_failure: shared.last_failure.clone(),
+            last_report: shared.last_report.clone(),
+        }
+    }
+
+    fn check_open(&self) -> Result<(), Error> {
+        let shared = lock(&self.inner.shared);
+        if shared.lifecycle == AppendStreamState::Open {
+            Ok(())
+        } else {
+            Err(error_from_shared(&shared))
+        }
+    }
+
+    fn closed_or_fatal_error(&self) -> Error {
+        error_from_shared(&lock(&self.inner.shared))
+    }
+
+    fn map_pending_error(&self, error: PendingAcquireError, requested: usize) -> Error {
+        match error {
+            PendingAcquireError::Closed => self.closed_or_fatal_error(),
+            PendingAcquireError::Full => Error::new(
+                ErrorKind::Unexpected,
+                "append stream local byte budget is full",
+            )
+            .set_temporary(),
+            PendingAcquireError::ExceedsCapacity => Error::new(
+                ErrorKind::Unexpected,
+                format!(
+                    "append row requires {requested} buffered bytes, exceeding max_pending_bytes={}",
+                    self.inner.pending_bytes.capacity
+                ),
+            )
+            .set_permanent(),
+        }
+    }
+
+    fn current_terminal_result(&self) -> TerminalResult {
+        let shared = lock(&self.inner.shared);
+        match shared.lifecycle {
+            AppendStreamState::Open => TerminalResult::Open,
+            AppendStreamState::Closing => TerminalResult::Waiting,
+            AppendStreamState::Closed | AppendStreamState::Failed
+                if shared.final_result.is_none() =>
+            {
+                TerminalResult::Waiting
+            }
+            AppendStreamState::Closed | AppendStreamState::Failed => {
+                TerminalResult::Complete(terminal_result(&shared))
+            }
+        }
+    }
+
+    async fn wait_for_terminal(&self) -> Result<AppendDeliveryReport, Error> {
+        loop {
+            let notified = self.inner.shutdown_notify.notified();
+            {
+                let shared = lock(&self.inner.shared);
+                if matches!(
+                    shared.lifecycle,
+                    AppendStreamState::Closed | AppendStreamState::Failed
+                ) && shared.final_result.is_some()
+                {
+                    return terminal_result(&shared);
+                }
+            }
+            notified.await;
+        }
+    }
+}
+
+enum TerminalResult {
+    Open,
+    Waiting,
+    Complete(Result<AppendDeliveryReport, Error>),
+}
+
+async fn enqueue_shutdown(inner: Arc<AppendStreamInner>) -> Result<AppendDeliveryReport, Error> {
+    let (ack, response) = oneshot::channel();
+    let dropped_rows_at_barrier = lock(&inner.shared).dropped_rows;
+    inner
+        .tx
+        .send(AppendCommand::Shutdown(BarrierCommand {
+            dropped_rows_at_barrier,
+            started_at: Instant::now(),
+            ack,
+        }))
+        .await
+        .map_err(|_| error_from_shared(&lock(&inner.shared)))?;
+    response
+        .await
+        .unwrap_or_else(|_| Err(error_from_shared(&lock(&inner.shared))))
+}
+
+fn terminal_result(shared: &SharedState) -> Result<AppendDeliveryReport, Error> {
+    match &shared.final_result {
+        Some(Ok(report)) => Ok(report.clone()),
+        Some(Err(error)) => Err(error.to_error()),
+        None => Err(error_from_shared(shared)),
+    }
+}
+
+fn error_from_shared(shared: &SharedState) -> Error {
+    shared
+        .fatal
+        .as_ref()
+        .map(StreamErrorSnapshot::to_error)
+        .unwrap_or_else(|| {
+            Error::new(ErrorKind::Unexpected, "append stream is closed").set_persistent()
+        })
+}
+
+fn prepare_record<T>(row: &T) -> Result<String, Error>
+where
+    T: Serialize + ?Sized,
+{
+    let payload = serde_json::to_string(row).map_err(|err| {
+        Error::new(ErrorKind::Unexpected, "failed to serialize append row").set_source(err)
+    })?;
+    validate_record_payload(&payload).map_err(|err| match err {
+        AppendTrySendError::RecordTooLarge { bytes, limit } => Error::new(
+            ErrorKind::Unexpected,
+            format!("append row is {bytes} bytes, exceeding the {limit}-byte limit"),
+        ),
+        _ => Error::new(
+            ErrorKind::Unexpected,
+            "append row must serialize to a JSON object",
+        ),
+    })?;
+    Ok(payload)
+}
+
+fn prepare_record_for_try_send<T>(row: &T) -> Result<String, AppendTrySendError>
+where
+    T: Serialize + ?Sized,
+{
+    let payload = serde_json::to_string(row).map_err(AppendTrySendError::Serialization)?;
+    validate_record_payload(&payload)?;
+    Ok(payload)
+}
+
+fn validate_record_payload(payload: &str) -> Result<(), AppendTrySendError> {
+    let bytes = payload.len();
+    if bytes > MAX_APPEND_BODY_BYTES {
+        return Err(AppendTrySendError::RecordTooLarge {
+            bytes,
+            limit: MAX_APPEND_BODY_BYTES,
+        });
+    }
+    if !payload.starts_with('{') {
+        return Err(AppendTrySendError::InvalidRecord);
+    }
+    Ok(())
+}
+
+#[derive(Debug, Clone, Copy)]
+enum SnapshotStatus {
+    Permanent,
+    Temporary,
+    Persistent,
+}
+
+#[derive(Debug, Clone)]
+struct StreamErrorSnapshot {
+    kind: ErrorKind,
+    message: String,
+    status: SnapshotStatus,
+    append_details: Option<AppendErrorDetails>,
+}
+
+impl StreamErrorSnapshot {
+    fn from_error(error: &Error) -> Self {
+        let status = if error.is_temporary() {
+            SnapshotStatus::Temporary
+        } else if error.is_persistent() {
+            SnapshotStatus::Persistent
+        } else {
+            SnapshotStatus::Permanent
+        };
+        Self {
+            kind: error.kind(),
+            message: error.message().to_string(),
+            status,
+            append_details: error.append_details().cloned(),
+        }
+    }
+
+    fn to_error(&self) -> Error {
+        let mut error = Error::new(self.kind, self.message.clone());
+        if let Some(details) = self.append_details.clone() {
+            error = error.set_append_details(details);
+        }
+        match self.status {
+            SnapshotStatus::Permanent => error.set_permanent(),
+            SnapshotStatus::Temporary => error.set_temporary(),
+            SnapshotStatus::Persistent => error.set_persistent(),
+        }
+    }
+
+    fn append_state(&self) -> Option<AppendState> {
+        self.append_details
+            .as_ref()
+            .map(|details| details.append_state)
+    }
+}
+
+struct BatchOutcome {
+    records: Vec<BufferedRecord>,
+    batch_bytes: usize,
+    result: Result<AppendRowsResult, Error>,
+    retries: usize,
+    circuit_probe: bool,
+}
+
+struct AppendBatchRequest {
+    client: Client,
+    database: String,
+    schema: String,
+    table: String,
+    retry: RetryConfig,
+    attempt_timeout: Option<Duration>,
+}
+
+struct AppendWorker {
+    config: AppendStreamConfig,
+    shared: Arc<Mutex<SharedState>>,
+    pending_bytes: Arc<PendingBytesBudget>,
+    shutdown_notify: Arc<Notify>,
+    rows: Vec<BufferedRecord>,
+    current_bytes: usize,
+    batch_deadline: Option<Instant>,
+    in_flight: JoinSet<BatchOutcome>,
+    interval: DeliveryCounters,
+    reported_dropped_rows: u64,
+    fatal: Option<StreamErrorSnapshot>,
+}
+
+async fn run_append_worker(
+    config: AppendStreamConfig,
+    mut rx: mpsc::Receiver<AppendCommand>,
+    shared: Arc<Mutex<SharedState>>,
+    pending_bytes: Arc<PendingBytesBudget>,
+    shutdown_notify: Arc<Notify>,
+) {
+    let mut worker = AppendWorker {
+        config,
+        shared,
+        pending_bytes,
+        shutdown_notify,
+        rows: Vec::new(),
+        current_bytes: 0,
+        batch_deadline: None,
+        in_flight: JoinSet::new(),
+        interval: DeliveryCounters::default(),
+        reported_dropped_rows: 0,
+        fatal: None,
+    };
+
+    loop {
+        if worker.fatal.is_some() {
+            worker.finish_fatal(&mut rx).await;
+            return;
+        }
+
+        let deadline = worker
+            .batch_deadline
+            .unwrap_or_else(|| Instant::now() + Duration::from_secs(86400 * 365));
+        tokio::select! {
+            biased;
+            outcome = worker.in_flight.join_next(), if !worker.in_flight.is_empty() => {
+                worker.handle_joined(outcome).await;
+            }
+            _ = tokio::time::sleep_until(deadline.into()), if worker.batch_deadline.is_some() => {
+                worker.dispatch_buffered().await;
+            }
+            command = rx.recv() => {
+                match command {
+                    Some(AppendCommand::Record(record)) => worker.buffer_record(record).await,
+                    Some(AppendCommand::Flush(barrier)) => {
+                        worker.complete_barrier(barrier).await;
+                    }
+                    Some(AppendCommand::Shutdown(barrier)) => {
+                        worker.complete_barrier(barrier).await;
+                        if worker.fatal.is_some() {
+                            worker.finish_fatal(&mut rx).await;
+                        } else {
+                            worker.finish_closed();
+                        }
+                        return;
+                    }
+                    None => {
+                        worker.dispatch_buffered().await;
+                        worker.drain_in_flight().await;
+                        if worker.fatal.is_some() {
+                            worker.finish_fatal(&mut rx).await;
+                        } else {
+                            let dropped = lock(&worker.shared).dropped_rows;
+                            let report = worker.take_report(dropped, Instant::now());
+                            worker.finish_closed_with_report(report);
+                        }
+                        return;
+                    }
+                }
+            }
+        }
+    }
+}
+
+async fn monitor_append_worker(
+    worker: JoinHandle<()>,
+    shared: Arc<Mutex<SharedState>>,
+    pending_bytes: Arc<PendingBytesBudget>,
+    shutdown_notify: Arc<Notify>,
+) {
+    let worker_result = worker.await;
+    let mut shared = lock(&shared);
+    if shared.final_result.is_some() {
+        return;
+    }
+
+    let error = match worker_result {
+        Ok(()) => Error::new(
+            ErrorKind::Unexpected,
+            "append stream worker stopped before publishing a final result",
+        )
+        .set_persistent(),
+        Err(error) => {
+            unknown_append_error("append stream worker terminated unexpectedly", Some(error))
+        }
+    };
+    let snapshot = StreamErrorSnapshot::from_error(&error);
+    let resolved = shared
+        .committed_rows
+        .saturating_add(shared.failed_rows)
+        .saturating_add(shared.unknown_rows);
+    let unresolved = shared.accepted_rows.saturating_sub(resolved);
+    shared.unknown_rows = shared.unknown_rows.saturating_add(unresolved);
+    shared.pending_rows = 0;
+    shared.pending_bytes = 0;
+    shared.in_flight_batches = 0;
+    shared.lifecycle = AppendStreamState::Failed;
+    shared.fatal = Some(snapshot.clone());
+    shared.final_result = Some(Err(snapshot));
+    drop(shared);
+    pending_bytes.close();
+    shutdown_notify.notify_waiters();
+}
+
+impl AppendWorker {
+    async fn buffer_record(&mut self, record: BufferedRecord) {
+        self.interval.accepted_rows = self.interval.accepted_rows.saturating_add(1);
+        let separator = usize::from(!self.rows.is_empty());
+        if !self.rows.is_empty()
+            && self
+                .current_bytes
+                .saturating_add(separator)
+                .saturating_add(record.payload.len())
+                > self.config.batch_bytes
+        {
+            self.dispatch_buffered().await;
+        }
+        if self.fatal.is_some() {
+            self.mark_records_failed(vec![record]);
+            return;
+        }
+
+        if self.rows.is_empty() {
+            self.batch_deadline = Some(deadline_after(self.config.flush_interval));
+        } else {
+            self.current_bytes = self.current_bytes.saturating_add(1);
+        }
+        self.current_bytes = self.current_bytes.saturating_add(record.payload.len());
+        self.rows.push(record);
+        if self.current_bytes >= self.config.batch_bytes || self.rows.len() >= MAX_APPEND_ROWS {
+            self.dispatch_buffered().await;
+        }
+    }
+
+    async fn dispatch_buffered(&mut self) {
+        if self.rows.is_empty() || self.fatal.is_some() {
+            return;
+        }
+        while self.in_flight.len() >= self.config.max_in_flight_requests {
+            let outcome = self.in_flight.join_next().await;
+            self.handle_joined(outcome).await;
+            if self.fatal.is_some() {
+                return;
+            }
+        }
+
+        let circuit_probe = self.wait_for_circuit().await;
+        if self.fatal.is_some() {
+            return;
+        }
+        let records = std::mem::take(&mut self.rows);
+        let batch_bytes = std::mem::take(&mut self.current_bytes);
+        self.batch_deadline = None;
+        let payload = records
+            .iter()
+            .map(|record| record.payload.as_str())
+            .collect::<Vec<_>>()
+            .join("\n");
+        let request = AppendBatchRequest {
+            client: self.config.client.clone(),
+            database: self.config.database.clone(),
+            schema: self.config.schema.clone(),
+            table: self.config.table.clone(),
+            retry: self.config.retry,
+            attempt_timeout: self.config.attempt_timeout,
+        };
+        lock(&self.shared).in_flight_batches += 1;
+        self.in_flight.spawn(async move {
+            let (result, retries) = append_batch(request, payload).await;
+            BatchOutcome {
+                records,
+                batch_bytes,
+                result,
+                retries,
+                circuit_probe,
+            }
+        });
+    }
+
+    async fn wait_for_circuit(&mut self) -> bool {
+        if self.config.failure_policy != AppendFailurePolicy::Continue
+            || self.config.circuit_breaker.is_none()
+        {
+            return false;
+        }
+
+        loop {
+            let (state, remaining) = {
+                let shared = lock(&self.shared);
+                let remaining = shared
+                    .circuit
+                    .opened_until
+                    .and_then(|until| until.checked_duration_since(Instant::now()));
+                (shared.circuit.state, remaining)
+            };
+            match state {
+                AppendCircuitState::Closed => return false,
+                AppendCircuitState::Open => {
+                    if let Some(remaining) = remaining {
+                        if self.in_flight.is_empty() {
+                            tokio::time::sleep(remaining).await;
+                        } else {
+                            tokio::select! {
+                                _ = tokio::time::sleep(remaining) => {}
+                                outcome = self.in_flight.join_next() => {
+                                    self.handle_joined(outcome).await;
+                                    if self.fatal.is_some() {
+                                        return false;
+                                    }
+                                }
+                            }
+                        }
+                        continue;
+                    }
+                    if !self.in_flight.is_empty() {
+                        self.drain_in_flight().await;
+                        if self.fatal.is_some() {
+                            return false;
+                        }
+                        continue;
+                    }
+                    let mut shared = lock(&self.shared);
+                    if shared.circuit.state == AppendCircuitState::Open {
+                        shared.circuit.state = AppendCircuitState::HalfOpen;
+                        return true;
+                    }
+                }
+                AppendCircuitState::HalfOpen => {
+                    if self.in_flight.is_empty() {
+                        return true;
+                    }
+                    let outcome = self.in_flight.join_next().await;
+                    self.handle_joined(outcome).await;
+                    if self.fatal.is_some() {
+                        return false;
+                    }
+                }
+            }
+        }
+    }
+
+    async fn complete_barrier(&mut self, barrier: BarrierCommand) {
+        self.dispatch_buffered().await;
+        self.drain_in_flight().await;
+        if let Some(fatal) = &self.fatal {
+            let _ = barrier.ack.send(Err(fatal.to_error()));
+            return;
+        }
+        let report = self.take_report(barrier.dropped_rows_at_barrier, barrier.started_at);
+        let _ = barrier.ack.send(Ok(report));
+    }
+
+    async fn drain_in_flight(&mut self) {
+        while let Some(outcome) = self.in_flight.join_next().await {
+            self.handle_joined(Some(outcome)).await;
+        }
+    }
+
+    async fn handle_joined(
+        &mut self,
+        outcome: Option<Result<BatchOutcome, tokio::task::JoinError>>,
+    ) {
+        let Some(outcome) = outcome else {
+            return;
+        };
+        let outcome = match outcome {
+            Ok(outcome) => outcome,
+            Err(error) => {
+                let fatal = unknown_append_error(
+                    "append stream background request task failed",
+                    Some(error),
+                );
+                self.set_fatal(StreamErrorSnapshot::from_error(&fatal));
+                return;
+            }
+        };
+
+        let rows = outcome.records.len() as u64;
+        let reserved_bytes = outcome
+            .records
+            .iter()
+            .map(|record| record.reserved_bytes)
+            .sum::<usize>();
+        let mut failure_event = None;
+        {
+            let mut shared = lock(&self.shared);
+            shared.in_flight_batches = shared.in_flight_batches.saturating_sub(1);
+            shared.pending_rows = shared.pending_rows.saturating_sub(rows);
+            shared.pending_bytes = shared.pending_bytes.saturating_sub(reserved_bytes);
+            shared.retries = shared.retries.saturating_add(outcome.retries as u64);
+            self.interval.retries = self.interval.retries.saturating_add(outcome.retries as u64);
+
+            match &outcome.result {
+                Ok(result) => {
+                    let committed = result.num_rows_inserted.max(0) as u64;
+                    shared.committed_rows = shared.committed_rows.saturating_add(committed);
+                    self.interval.committed_rows =
+                        self.interval.committed_rows.saturating_add(committed);
+                    self.interval.committed_batches =
+                        self.interval.committed_batches.saturating_add(1);
+                    record_circuit_success(&mut shared, outcome.circuit_probe);
+                }
+                Err(error) => {
+                    let snapshot = StreamErrorSnapshot::from_error(error);
+                    let append_state = snapshot.append_state().unwrap_or(AppendState::Unknown);
+                    if append_state == AppendState::Unknown {
+                        shared.unknown_rows = shared.unknown_rows.saturating_add(rows);
+                        self.interval.unknown_rows =
+                            self.interval.unknown_rows.saturating_add(rows);
+                        self.interval.unknown_batches =
+                            self.interval.unknown_batches.saturating_add(1);
+                    } else {
+                        shared.failed_rows = shared.failed_rows.saturating_add(rows);
+                        self.interval.failed_rows = self.interval.failed_rows.saturating_add(rows);
+                        self.interval.failed_batches =
+                            self.interval.failed_batches.saturating_add(1);
+                    }
+                    shared.last_failure = Some(AppendLastFailure {
+                        at: SystemTime::now(),
+                        message: error.message().to_string(),
+                        append_state: Some(append_state),
+                    });
+                    let circuit_opened = self.config.failure_policy
+                        == AppendFailurePolicy::Continue
+                        && record_circuit_failure(
+                            &mut shared,
+                            self.config.circuit_breaker,
+                            error,
+                            outcome.circuit_probe,
+                        );
+                    let action = if self.config.failure_policy == AppendFailurePolicy::Stop {
+                        AppendBatchFailureAction::Stopped
+                    } else if circuit_opened {
+                        AppendBatchFailureAction::CircuitOpened
+                    } else {
+                        AppendBatchFailureAction::Continuing
+                    };
+                    failure_event = Some(AppendBatchFailureEvent {
+                        error: snapshot.to_error(),
+                        batch_rows: rows as usize,
+                        batch_bytes: outcome.batch_bytes,
+                        outcome: append_state,
+                        action,
+                    });
+                    if self.config.failure_policy == AppendFailurePolicy::Stop {
+                        drop(shared);
+                        self.set_fatal(snapshot);
+                    }
+                }
+            }
+        }
+        drop(outcome.records);
+
+        if let Some(event) = &failure_event {
+            for listener in &self.config.batch_failure_listeners {
+                let _ = std::panic::catch_unwind(AssertUnwindSafe(|| listener(event)));
+            }
+        }
+    }
+
+    fn set_fatal(&mut self, snapshot: StreamErrorSnapshot) {
+        let replace = match &self.fatal {
+            None => true,
+            Some(current) => {
+                current.append_state() != Some(AppendState::Unknown)
+                    && snapshot.append_state() == Some(AppendState::Unknown)
+            }
+        };
+        if replace {
+            self.fatal = Some(snapshot.clone());
+        }
+        let fatal = self.fatal.clone().expect("fatal state must be set");
+        let mut shared = lock(&self.shared);
+        shared.lifecycle = AppendStreamState::Failed;
+        shared.fatal = Some(fatal);
+        drop(shared);
+        self.pending_bytes.close();
+    }
+
+    fn mark_records_failed(&mut self, records: Vec<BufferedRecord>) {
+        if records.is_empty() {
+            return;
+        }
+        let rows = records.len() as u64;
+        let bytes = records
+            .iter()
+            .map(|record| record.reserved_bytes)
+            .sum::<usize>();
+        let mut shared = lock(&self.shared);
+        shared.failed_rows = shared.failed_rows.saturating_add(rows);
+        shared.pending_rows = shared.pending_rows.saturating_sub(rows);
+        shared.pending_bytes = shared.pending_bytes.saturating_sub(bytes);
+        self.interval.failed_rows = self.interval.failed_rows.saturating_add(rows);
+        drop(shared);
+        drop(records);
+    }
+
+    async fn finish_fatal(&mut self, rx: &mut mpsc::Receiver<AppendCommand>) {
+        rx.close();
+        let buffered = std::mem::take(&mut self.rows);
+        self.mark_records_failed(buffered);
+        self.current_bytes = 0;
+        self.batch_deadline = None;
+
+        let mut barriers = Vec::new();
+        while let Some(command) = rx.recv().await {
+            match command {
+                AppendCommand::Record(record) => {
+                    self.interval.accepted_rows = self.interval.accepted_rows.saturating_add(1);
+                    self.mark_records_failed(vec![record]);
+                }
+                AppendCommand::Flush(barrier) | AppendCommand::Shutdown(barrier) => {
+                    barriers.push(barrier.ack);
+                }
+            }
+        }
+        self.drain_in_flight().await;
+
+        let fatal = self.fatal.clone().unwrap_or_else(|| {
+            StreamErrorSnapshot::from_error(&Error::new(
+                ErrorKind::Unexpected,
+                "append stream failed",
+            ))
+        });
+        {
+            let mut shared = lock(&self.shared);
+            let resolved = shared
+                .committed_rows
+                .saturating_add(shared.failed_rows)
+                .saturating_add(shared.unknown_rows);
+            let unresolved = shared.accepted_rows.saturating_sub(resolved);
+            if unresolved > 0 {
+                shared.unknown_rows = shared.unknown_rows.saturating_add(unresolved);
+                self.interval.unknown_rows = self.interval.unknown_rows.saturating_add(unresolved);
+                self.interval.unknown_batches = self.interval.unknown_batches.saturating_add(1);
+            }
+            shared.pending_rows = 0;
+            shared.pending_bytes = 0;
+            shared.in_flight_batches = 0;
+            shared.lifecycle = AppendStreamState::Failed;
+            shared.fatal = Some(fatal.clone());
+            shared.final_result = Some(Err(fatal.clone()));
+        }
+        for ack in barriers {
+            let _ = ack.send(Err(fatal.to_error()));
+        }
+        self.pending_bytes.close();
+        self.shutdown_notify.notify_waiters();
+    }
+
+    fn take_report(
+        &mut self,
+        dropped_rows_at_barrier: u64,
+        started_at: Instant,
+    ) -> AppendDeliveryReport {
+        let dropped_rows = dropped_rows_at_barrier.saturating_sub(self.reported_dropped_rows);
+        self.reported_dropped_rows = self.reported_dropped_rows.max(dropped_rows_at_barrier);
+        let lost_rows = self
+            .interval
+            .failed_rows
+            .saturating_add(self.interval.unknown_rows)
+            .saturating_add(dropped_rows);
+        let outcome = if lost_rows == 0 {
+            AppendDeliveryOutcome::Ok
+        } else if self.interval.committed_rows > 0 {
+            AppendDeliveryOutcome::Partial
+        } else if self.interval.unknown_rows > 0 {
+            AppendDeliveryOutcome::Unknown
+        } else {
+            AppendDeliveryOutcome::Failed
+        };
+        let report = AppendDeliveryReport {
+            outcome,
+            accepted_rows: self.interval.accepted_rows,
+            committed_rows: self.interval.committed_rows,
+            failed_rows: self.interval.failed_rows,
+            unknown_rows: self.interval.unknown_rows,
+            dropped_rows,
+            committed_batches: self.interval.committed_batches,
+            failed_batches: self.interval.failed_batches,
+            unknown_batches: self.interval.unknown_batches,
+            retries: self.interval.retries,
+            duration: started_at.elapsed(),
+        };
+        self.interval = DeliveryCounters::default();
+        let mut shared = lock(&self.shared);
+        shared.last_report = Some(report.clone());
+        report
+    }
+
+    fn finish_closed(&mut self) {
+        let report = lock(&self.shared)
+            .last_report
+            .clone()
+            .unwrap_or_else(empty_report);
+        self.finish_closed_with_report(report);
+    }
+
+    fn finish_closed_with_report(&mut self, report: AppendDeliveryReport) {
+        let mut shared = lock(&self.shared);
+        shared.lifecycle = AppendStreamState::Closed;
+        shared.last_report = Some(report.clone());
+        shared.final_result = Some(Ok(report));
+        drop(shared);
+        self.pending_bytes.close();
+        self.shutdown_notify.notify_waiters();
+    }
+}
+
+async fn append_batch(
+    request: AppendBatchRequest,
+    payload: String,
+) -> (Result<AppendRowsResult, Error>, usize) {
+    let mut retries = 0usize;
+    let mut backoff = request.retry.initial_backoff;
+    loop {
+        let append = request.client.append_rows(
+            &request.database,
+            &request.schema,
+            &request.table,
+            payload.clone(),
+        );
+        let result = if let Some(timeout) = request.attempt_timeout {
+            match tokio::time::timeout(timeout, append).await {
+                Ok(result) => result,
+                Err(error) => Err(unknown_append_error(
+                    "append request timed out; commit outcome is unknown",
+                    Some(error),
+                )),
+            }
+        } else {
+            append.await
+        };
+
+        match result {
+            Ok(result) => return (Ok(result), retries),
+            Err(error) if append_retryable(&error) && retries < request.retry.max_retries => {
+                if !backoff.is_zero() {
+                    tokio::time::sleep(backoff).await;
+                }
+                retries += 1;
+                backoff = next_backoff(backoff, request.retry.max_backoff);
+            }
+            Err(error) if append_retryable(&error) => {
+                return (
+                    Err(error.with_context("retries", retries).set_persistent()),
+                    retries,
+                );
+            }
+            Err(error) => return (Err(error), retries),
+        }
+    }
+}
+
+fn append_retryable(error: &Error) -> bool {
+    error.is_temporary()
+        && error
+            .append_details()
+            .is_some_and(|details| details.append_state == AppendState::Rejected)
+}
+
+fn unknown_append_error<E>(message: impl Into<String>, source: Option<E>) -> Error
+where
+    E: Into<anyhow::Error>,
+{
+    let mut error =
+        Error::new(ErrorKind::AppendRowsFailed, message).set_append_details(AppendErrorDetails {
+            append_state: AppendState::Unknown,
+            row_errors: Vec::new(),
+            row_errors_truncated: false,
+        });
+    if let Some(source) = source {
+        error = error.set_source(source);
+    }
+    error.set_persistent()
+}
+
+fn next_backoff(current: Duration, max_backoff: Duration) -> Duration {
+    if current.is_zero() {
+        return Duration::ZERO;
+    }
+    current
+        .checked_mul(2)
+        .unwrap_or(max_backoff)
+        .min(max_backoff)
+}
+
+fn try_claim_circuit_admission(shared: &mut SharedState) -> bool {
+    match shared.circuit.state {
+        AppendCircuitState::Closed => true,
+        AppendCircuitState::HalfOpen => false,
+        AppendCircuitState::Open => {
+            let cooled_down = shared
+                .circuit
+                .opened_until
+                .is_none_or(|until| Instant::now() >= until);
+            if cooled_down && !shared.circuit.probe_admission_claimed {
+                shared.circuit.probe_admission_claimed = true;
+                true
+            } else {
+                false
+            }
+        }
+    }
+}
+
+fn circuit_admission_available(shared: &SharedState) -> bool {
+    match shared.circuit.state {
+        AppendCircuitState::Closed => true,
+        AppendCircuitState::HalfOpen => false,
+        AppendCircuitState::Open => {
+            shared
+                .circuit
+                .opened_until
+                .is_none_or(|until| Instant::now() >= until)
+                && !shared.circuit.probe_admission_claimed
+        }
+    }
+}
+
+fn record_circuit_success(shared: &mut SharedState, probe: bool) {
+    shared.circuit.consecutive_failures = 0;
+    if probe {
+        shared.circuit.state = AppendCircuitState::Closed;
+        shared.circuit.opened_until = None;
+        shared.circuit.probe_admission_claimed = false;
+    }
+}
+
+fn record_circuit_failure(
+    shared: &mut SharedState,
+    options: Option<AppendCircuitBreakerOptions>,
+    error: &Error,
+    probe: bool,
+) -> bool {
+    let Some(options) = options else {
+        return false;
+    };
+    let availability_failure = error.is_temporary()
+        || error.is_persistent()
+        || error
+            .append_details()
+            .is_some_and(|details| details.append_state == AppendState::Unknown);
+    if !availability_failure {
+        if probe {
+            record_circuit_success(shared, true);
+        }
+        return false;
+    }
+
+    shared.circuit.consecutive_failures = shared.circuit.consecutive_failures.saturating_add(1);
+    if probe || shared.circuit.consecutive_failures >= options.failure_threshold {
+        shared.circuit.state = AppendCircuitState::Open;
+        shared.circuit.opened_until = Some(deadline_after(options.cooldown));
+        shared.circuit.probe_admission_claimed = false;
+        true
+    } else {
+        false
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum DropReason {
+    BufferFull,
+    InvalidRecord,
+    RecordTooLarge,
+    CircuitOpen,
+    Closed,
+}
+
+fn note_drop(shared: &mut SharedState, reason: DropReason) {
+    shared.dropped_rows = shared.dropped_rows.saturating_add(1);
+    let counter = match reason {
+        DropReason::BufferFull => &mut shared.dropped_by_reason.buffer_full,
+        DropReason::InvalidRecord => &mut shared.dropped_by_reason.invalid_record,
+        DropReason::RecordTooLarge => &mut shared.dropped_by_reason.record_too_large,
+        DropReason::CircuitOpen => &mut shared.dropped_by_reason.circuit_open,
+        DropReason::Closed => &mut shared.dropped_by_reason.closed,
+    };
+    *counter = counter.saturating_add(1);
+}
+
+fn empty_report() -> AppendDeliveryReport {
+    AppendDeliveryReport {
+        outcome: AppendDeliveryOutcome::Ok,
+        accepted_rows: 0,
+        committed_rows: 0,
+        failed_rows: 0,
+        unknown_rows: 0,
+        dropped_rows: 0,
+        committed_batches: 0,
+        failed_batches: 0,
+        unknown_batches: 0,
+        retries: 0,
+        duration: Duration::ZERO,
+    }
+}
+
+fn deadline_after(duration: Duration) -> Instant {
+    let now = Instant::now();
+    now.checked_add(duration).unwrap_or(now)
+}
+
+fn lock<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
+    mutex
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::io::Read;
+    use std::io::Write;
+    use std::net::TcpListener;
+    use std::net::TcpStream;
+    use std::sync::atomic::AtomicUsize;
+    use std::thread;
+
+    use super::*;
+
+    #[derive(Debug, Clone)]
+    struct RecordedRequest {
+        target: String,
+        headers: HashMap<String, String>,
+        body: String,
+    }
+
+    #[derive(Debug, Clone)]
+    struct MockResponse {
+        status: u16,
+        body: String,
+        delay: Duration,
+    }
+
+    impl MockResponse {
+        fn json(status: u16, body: impl Into<String>) -> Self {
+            Self {
+                status,
+                body: body.into(),
+                delay: Duration::ZERO,
+            }
+        }
+
+        fn committed(request: &RecordedRequest) -> Self {
+            let rows = request
+                .body
+                .lines()
+                .filter(|line| !line.trim().is_empty())
+                .count();
+            Self::json(
+                200,
+                format!(r#"{{"append_state":"committed","num_rows_inserted":{rows}}}"#),
+            )
+        }
+
+        fn with_delay(mut self, delay: Duration) -> Self {
+            self.delay = delay;
+            self
+        }
+    }
+
+    type Responder = dyn Fn(usize, &RecordedRequest) -> MockResponse + Send + Sync;
+
+    struct MockServer {
+        endpoint: String,
+        requests: Arc<Mutex<Vec<RecordedRequest>>>,
+        max_active: Arc<AtomicUsize>,
+        stop: Arc<AtomicBool>,
+        accept_task: Option<thread::JoinHandle<()>>,
+    }
+
+    impl MockServer {
+        fn start<F>(responder: F) -> Self
+        where
+            F: Fn(usize, &RecordedRequest) -> MockResponse + Send + Sync + 'static,
+        {
+            let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+            listener.set_nonblocking(true).unwrap();
+            let address = listener.local_addr().unwrap();
+            let endpoint = format!("http://{address}");
+            let requests = Arc::new(Mutex::new(Vec::new()));
+            let active = Arc::new(AtomicUsize::new(0));
+            let max_active = Arc::new(AtomicUsize::new(0));
+            let stop = Arc::new(AtomicBool::new(false));
+            let responder: Arc<Responder> = Arc::new(responder);
+
+            let accept_task = thread::spawn({
+                let requests = requests.clone();
+                let active = active.clone();
+                let max_active = max_active.clone();
+                let stop = stop.clone();
+                move || {
+                    while !stop.load(Ordering::Acquire) {
+                        match listener.accept() {
+                            Ok((stream, _)) => {
+                                if stop.load(Ordering::Acquire) {
+                                    break;
+                                }
+                                let requests = requests.clone();
+                                let active = active.clone();
+                                let max_active = max_active.clone();
+                                let responder = responder.clone();
+                                thread::spawn(move || {
+                                    handle_connection(
+                                        stream, requests, active, max_active, responder,
+                                    );
+                                });
+                            }
+                            Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                                thread::sleep(Duration::from_millis(1));
+                            }
+                            Err(_) => break,
+                        }
+                    }
+                }
+            });
+
+            Self {
+                endpoint,
+                requests,
+                max_active,
+                stop,
+                accept_task: Some(accept_task),
+            }
+        }
+
+        fn client(&self) -> Client {
+            let http_client = reqwest::Client::builder().no_proxy().build().unwrap();
+            Client::new(&self.endpoint, http_client).unwrap()
+        }
+
+        fn requests(&self) -> Vec<RecordedRequest> {
+            lock(&self.requests).clone()
+        }
+
+        fn max_active(&self) -> usize {
+            self.max_active.load(Ordering::Acquire)
+        }
+    }
+
+    impl Drop for MockServer {
+        fn drop(&mut self) {
+            self.stop.store(true, Ordering::Release);
+            let _ = TcpStream::connect(self.endpoint.trim_start_matches("http://"));
+            if let Some(task) = self.accept_task.take() {
+                let _ = task.join();
+            }
+        }
+    }
+
+    fn handle_connection(
+        mut stream: TcpStream,
+        requests: Arc<Mutex<Vec<RecordedRequest>>>,
+        active: Arc<AtomicUsize>,
+        max_active: Arc<AtomicUsize>,
+        responder: Arc<Responder>,
+    ) {
+        stream
+            .set_read_timeout(Some(Duration::from_secs(2)))
+            .unwrap();
+        let Some(request) = read_request(&mut stream) else {
+            return;
+        };
+        let index = {
+            let mut recorded = lock(&requests);
+            let index = recorded.len();
+            recorded.push(request.clone());
+            index
+        };
+        let now_active = active.fetch_add(1, Ordering::AcqRel) + 1;
+        max_active.fetch_max(now_active, Ordering::AcqRel);
+        let response = responder(index, &request);
+        if !response.delay.is_zero() {
+            thread::sleep(response.delay);
+        }
+        let reason = match response.status {
+            200 => "OK",
+            400 => "Bad Request",
+            422 => "Unprocessable Entity",
+            503 => "Service Unavailable",
+            _ => "Test Response",
+        };
+        let wire = format!(
+            "HTTP/1.1 {} {}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            response.status,
+            reason,
+            response.body.len(),
+            response.body
+        );
+        let _ = stream.write_all(wire.as_bytes());
+        let _ = stream.flush();
+        active.fetch_sub(1, Ordering::AcqRel);
+    }
+
+    fn read_request(stream: &mut TcpStream) -> Option<RecordedRequest> {
+        let mut bytes = Vec::new();
+        let mut buffer = [0u8; 4096];
+        let header_end = loop {
+            let read = stream.read(&mut buffer).ok()?;
+            if read == 0 {
+                return None;
+            }
+            bytes.extend_from_slice(&buffer[..read]);
+            if let Some(position) = bytes.windows(4).position(|window| window == b"\r\n\r\n") {
+                break position + 4;
+            }
+        };
+        let headers_text = String::from_utf8(bytes[..header_end].to_vec()).ok()?;
+        let mut lines = headers_text.split("\r\n");
+        let target = lines.next()?.split_whitespace().nth(1)?.to_string();
+        let mut headers = HashMap::new();
+        for line in lines.filter(|line| !line.is_empty()) {
+            let (name, value) = line.split_once(':')?;
+            headers.insert(name.trim().to_ascii_lowercase(), value.trim().to_string());
+        }
+        let content_length = headers
+            .get("content-length")
+            .and_then(|value| value.parse::<usize>().ok())
+            .unwrap_or(0);
+        while bytes.len().saturating_sub(header_end) < content_length {
+            let read = stream.read(&mut buffer).ok()?;
+            if read == 0 {
+                return None;
+            }
+            bytes.extend_from_slice(&buffer[..read]);
+        }
+        let body = String::from_utf8(
+            bytes[header_end..header_end.saturating_add(content_length)].to_vec(),
+        )
+        .ok()?;
+        Some(RecordedRequest {
+            target,
+            headers,
+            body,
+        })
+    }
+
+    #[test]
+    fn rejects_non_object_rows() {
+        assert!(matches!(
+            prepare_record_for_try_send(&vec![1, 2, 3]),
+            Err(AppendTrySendError::InvalidRecord)
+        ));
+    }
+
+    #[test]
+    fn report_outcomes_include_drops_and_unknown_rows() {
+        let config = AppendStreamConfig {
+            client: Client::new("http://127.0.0.1:1", reqwest::Client::new()).unwrap(),
+            database: "scopedb".to_string(),
+            schema: "public".to_string(),
+            table: "events".to_string(),
+            batch_bytes: 1024,
+            flush_interval: Duration::from_secs(1),
+            channel_capacity: 1,
+            max_pending_bytes: 1024,
+            max_in_flight_requests: 1,
+            retry: RetryConfig {
+                max_retries: 0,
+                initial_backoff: Duration::ZERO,
+                max_backoff: Duration::ZERO,
+            },
+            failure_policy: AppendFailurePolicy::Continue,
+            attempt_timeout: Some(Duration::from_secs(1)),
+            circuit_breaker: None,
+            batch_failure_listeners: Vec::new(),
+        };
+        let shared = Arc::new(Mutex::new(SharedState::default()));
+        let budget = Arc::new(PendingBytesBudget::new(1024));
+        let mut worker = AppendWorker {
+            config,
+            shared,
+            pending_bytes: budget,
+            shutdown_notify: Arc::new(Notify::new()),
+            rows: Vec::new(),
+            current_bytes: 0,
+            batch_deadline: None,
+            in_flight: JoinSet::new(),
+            interval: DeliveryCounters {
+                accepted_rows: 2,
+                committed_rows: 1,
+                unknown_rows: 1,
+                ..DeliveryCounters::default()
+            },
+            reported_dropped_rows: 0,
+            fatal: None,
+        };
+        let report = worker.take_report(1, Instant::now());
+        assert_eq!(report.outcome, AppendDeliveryOutcome::Partial);
+        assert_eq!(report.dropped_rows, 1);
+    }
+
+    #[test]
+    fn backoff_is_capped() {
+        assert_eq!(
+            next_backoff(Duration::from_secs(4), Duration::from_secs(5)),
+            Duration::from_secs(5)
+        );
+    }
+
+    #[tokio::test]
+    async fn batches_ndjson_and_runs_requests_concurrently() {
+        let server = MockServer::start(|_, request| {
+            MockResponse::committed(request).with_delay(Duration::from_millis(30))
+        });
+        let stream = server
+            .client()
+            .table("events/archive")
+            .with_database("analytics 2026")
+            .with_schema("public")
+            .append_stream()
+            .batch_bytes(1)
+            .max_in_flight_requests(3)
+            .build()
+            .unwrap();
+
+        let admitted = stream
+            .send_all((0..6).map(|id| serde_json::json!({"id": id})))
+            .await
+            .unwrap();
+        let report = stream.shutdown().await.unwrap();
+
+        assert_eq!(admitted.accepted_rows, 6);
+        assert_eq!(report.outcome, AppendDeliveryOutcome::Ok);
+        assert_eq!(report.accepted_rows, 6);
+        assert_eq!(report.committed_rows, 6);
+        assert_eq!(report.committed_batches, 6);
+        assert!(server.max_active() >= 2);
+        let requests = server.requests();
+        assert_eq!(requests.len(), 6);
+        for request in requests {
+            assert_eq!(
+                request.target,
+                "/v1/databases/analytics%202026/schemas/public/tables/events%2Farchive/rows"
+            );
+            assert_eq!(
+                request.headers.get("content-type").map(String::as_str),
+                Some("application/x-ndjson")
+            );
+            assert_eq!(request.body.lines().count(), 1);
+            assert!(request.body.starts_with('{'));
+        }
+    }
+
+    #[tokio::test]
+    async fn continue_mode_retries_only_temporary_rejections() {
+        let server = MockServer::start(|index, request| match index {
+            0 => MockResponse::json(503, r#"{"message":"busy","append_state":"rejected"}"#),
+            1 => MockResponse::committed(request),
+            2 => MockResponse::json(503, r#"{"message":"ambiguous","append_state":"unknown"}"#),
+            3 => MockResponse::json(422, r#"{"message":"bad row","append_state":"rejected"}"#),
+            _ => panic!("unexpected retry request {index}"),
+        });
+        let stream = server
+            .client()
+            .table("events")
+            .append_stream()
+            .failure_policy(AppendFailurePolicy::Continue)
+            .circuit_breaker(None)
+            .batch_bytes(1)
+            .max_in_flight_requests(1)
+            .max_retries(4)
+            .initial_backoff(Duration::ZERO)
+            .max_backoff(Duration::ZERO)
+            .build()
+            .unwrap();
+
+        stream
+            .send_all((0..3).map(|id| serde_json::json!({"id": id})))
+            .await
+            .unwrap();
+        let report = stream.shutdown().await.unwrap();
+
+        assert_eq!(server.requests().len(), 4);
+        assert_eq!(report.outcome, AppendDeliveryOutcome::Partial);
+        assert_eq!(report.accepted_rows, 3);
+        assert_eq!(report.committed_rows, 1);
+        assert_eq!(report.failed_rows, 1);
+        assert_eq!(report.unknown_rows, 1);
+        assert_eq!(report.committed_batches, 1);
+        assert_eq!(report.failed_batches, 1);
+        assert_eq!(report.unknown_batches, 1);
+        assert_eq!(report.retries, 1);
+        assert_eq!(
+            report.accepted_rows,
+            report.committed_rows + report.failed_rows + report.unknown_rows
+        );
+    }
+
+    #[tokio::test]
+    async fn unknown_timeout_is_not_retried() {
+        let server = MockServer::start(|_, request| {
+            MockResponse::committed(request).with_delay(Duration::from_millis(100))
+        });
+        let stream = server
+            .client()
+            .table("events")
+            .append_stream()
+            .failure_policy(AppendFailurePolicy::Continue)
+            .circuit_breaker(None)
+            .batch_bytes(1)
+            .max_retries(8)
+            .attempt_timeout(Duration::from_millis(10))
+            .build()
+            .unwrap();
+
+        stream.send(&serde_json::json!({"id": 1})).await.unwrap();
+        let report = stream.shutdown().await.unwrap();
+
+        assert_eq!(server.requests().len(), 1);
+        assert_eq!(report.outcome, AppendDeliveryOutcome::Unknown);
+        assert_eq!(report.unknown_rows, 1);
+        assert_eq!(report.retries, 0);
+    }
+
+    #[tokio::test]
+    async fn stop_policy_closes_after_a_rejected_batch() {
+        let server = MockServer::start(|_, _| {
+            MockResponse::json(422, r#"{"message":"invalid","append_state":"rejected"}"#)
+                .with_delay(Duration::from_millis(20))
+        });
+        let stream = server
+            .client()
+            .table("events")
+            .append_stream()
+            .batch_bytes(1)
+            .max_in_flight_requests(1)
+            .build()
+            .unwrap();
+        stream
+            .send_all((0..2).map(|id| serde_json::json!({"id": id})))
+            .await
+            .unwrap();
+
+        let error = stream.shutdown().await.unwrap_err();
+        assert_eq!(error.kind(), ErrorKind::AppendRowsFailed);
+        assert_eq!(
+            error.append_details().map(|details| details.append_state),
+            Some(AppendState::Rejected)
+        );
+        let stats = stream.stats();
+        assert_eq!(stats.state, AppendStreamState::Failed);
+        assert_eq!(stats.accepted_rows, 2);
+        assert_eq!(stats.failed_rows, 2);
+        assert_eq!(stats.pending_rows, 0);
+        assert!(matches!(
+            stream.try_send(&serde_json::json!({"id": 3})),
+            Err(AppendTrySendError::Closed)
+        ));
+    }
+
+    #[tokio::test]
+    async fn strict_terminal_waits_for_every_in_flight_outcome() {
+        let server = MockServer::start(|index, _| match index {
+            0 => MockResponse::json(422, r#"{"message":"invalid","append_state":"rejected"}"#)
+                .with_delay(Duration::from_millis(5)),
+            1 => MockResponse::json(503, r#"{"message":"ambiguous","append_state":"unknown"}"#)
+                .with_delay(Duration::from_millis(80)),
+            _ => panic!("unexpected request {index}"),
+        });
+        let stream = server
+            .client()
+            .table("events")
+            .append_stream()
+            .batch_bytes(1)
+            .max_in_flight_requests(2)
+            .build()
+            .unwrap();
+        stream
+            .send_all((0..2).map(|id| serde_json::json!({"id": id})))
+            .await
+            .unwrap();
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while stream.stats().state != AppendStreamState::Failed {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap();
+        let started = Instant::now();
+        let error = stream.shutdown().await.unwrap_err();
+
+        assert!(started.elapsed() >= Duration::from_millis(40));
+        assert_eq!(
+            error.append_details().map(|details| details.append_state),
+            Some(AppendState::Unknown)
+        );
+        let stats = stream.stats();
+        assert_eq!(stats.failed_rows, 1);
+        assert_eq!(stats.unknown_rows, 1);
+        assert_eq!(stats.pending_rows, 0);
+    }
+
+    #[tokio::test]
+    async fn concurrent_flush_and_shutdown_both_settle() {
+        let server = MockServer::start(|_, request| {
+            MockResponse::committed(request).with_delay(Duration::from_millis(5))
+        });
+        let stream = server
+            .client()
+            .table("events")
+            .append_stream()
+            .build()
+            .unwrap();
+        stream.send(&serde_json::json!({"id": 1})).await.unwrap();
+
+        let (flush, shutdown) = tokio::join!(stream.flush(), stream.shutdown());
+        assert!(flush.is_ok(), "flush failed: {flush:?}");
+        assert!(shutdown.is_ok(), "shutdown failed: {shutdown:?}");
+        assert_eq!(stream.stats().state, AppendStreamState::Closed);
+    }
+
+    #[tokio::test]
+    async fn shutdown_is_idempotent_across_clones() {
+        let server = MockServer::start(|_, request| MockResponse::committed(request));
+        let stream = server
+            .client()
+            .table("events")
+            .append_stream()
+            .build()
+            .unwrap();
+        let clone = stream.clone();
+        stream.send(&serde_json::json!({"id": 1})).await.unwrap();
+
+        let (first, second) = tokio::join!(stream.shutdown(), clone.shutdown());
+        assert_eq!(first.unwrap(), second.unwrap());
+        assert_eq!(server.requests().len(), 1);
+        assert!(matches!(
+            stream.try_send(&serde_json::json!({"id": 2})),
+            Err(AppendTrySendError::Closed)
+        ));
+    }
+
+    #[tokio::test]
+    async fn try_send_accounts_for_local_drops() {
+        let client = Client::new("http://127.0.0.1:1", reqwest::Client::new()).unwrap();
+        let stream = client
+            .table("events")
+            .append_stream()
+            .failure_policy(AppendFailurePolicy::Continue)
+            .max_pending_bytes(1)
+            .build()
+            .unwrap();
+
+        assert!(matches!(
+            stream.try_send(&serde_json::json!({"id": 1})),
+            Err(AppendTrySendError::BufferFull)
+        ));
+        let report = stream.shutdown().await.unwrap();
+        assert_eq!(report.outcome, AppendDeliveryOutcome::Failed);
+        assert_eq!(report.accepted_rows, 0);
+        assert_eq!(report.dropped_rows, 1);
+        assert_eq!(stream.stats().dropped_by_reason.buffer_full, 1);
+    }
+}

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -14,7 +14,10 @@
 
 use fastrace_reqwest::traceparent_headers;
 use reqwest::IntoUrl;
+use reqwest::StatusCode;
 use reqwest::Url;
+use serde::Deserialize;
+use serde::de::DeserializeOwned;
 use uuid::Uuid;
 
 use crate::Error;
@@ -22,16 +25,26 @@ use crate::ErrorKind;
 use crate::IngestStreamBuilder;
 use crate::Statement;
 use crate::Table;
+use crate::protocol::AppendErrorDetails;
+use crate::protocol::AppendRowsErrorPayload;
+use crate::protocol::AppendRowsResult;
+use crate::protocol::AppendState;
+use crate::protocol::CatalogListOptions;
+use crate::protocol::CatalogPage;
+use crate::protocol::DatabaseResource;
 use crate::protocol::IngestData;
 use crate::protocol::IngestRequest;
 use crate::protocol::IngestResult;
 use crate::protocol::IngestType;
 use crate::protocol::Response;
 use crate::protocol::ResultFormat;
+use crate::protocol::SchemaResource;
 use crate::protocol::StatementCancelResult;
 use crate::protocol::StatementRequest;
 use crate::protocol::StatementRequestParams;
 use crate::protocol::StatementStatus;
+use crate::protocol::TableResource;
+use crate::protocol::TableResourceSummary;
 use crate::statement::StatementHandle;
 
 #[derive(Debug, Clone)]
@@ -43,7 +56,13 @@ pub struct Client {
 impl Client {
     pub fn new<E: IntoUrl>(endpoint: E, client: reqwest::Client) -> Result<Self, Error> {
         match endpoint.into_url() {
-            Ok(endpoint) => Ok(Self { endpoint, client }),
+            Ok(mut endpoint) => {
+                if !endpoint.path().ends_with('/') {
+                    let path = format!("{}/", endpoint.path());
+                    endpoint.set_path(&path);
+                }
+                Ok(Self { endpoint, client })
+            }
             Err(err) => Err(Error::new(
                 ErrorKind::ConfigInvalid,
                 "failed to parse endpoint".to_string(),
@@ -80,6 +99,121 @@ impl Client {
         Ok(())
     }
 
+    pub async fn list_databases(
+        &self,
+        options: CatalogListOptions,
+    ) -> Result<CatalogPage<DatabaseResource>, Error> {
+        self.fetch_catalog(&["databases"], Some(&options), "failed to list databases")
+            .await
+    }
+
+    pub async fn fetch_database(&self, database: &str) -> Result<DatabaseResource, Error> {
+        self.fetch_catalog(&["databases", database], None, "failed to fetch database")
+            .await
+    }
+
+    pub async fn list_schemas(
+        &self,
+        database: &str,
+        options: CatalogListOptions,
+    ) -> Result<CatalogPage<SchemaResource>, Error> {
+        self.fetch_catalog(
+            &["databases", database, "schemas"],
+            Some(&options),
+            "failed to list schemas",
+        )
+        .await
+    }
+
+    pub async fn fetch_schema(
+        &self,
+        database: &str,
+        schema: &str,
+    ) -> Result<SchemaResource, Error> {
+        self.fetch_catalog(
+            &["databases", database, "schemas", schema],
+            None,
+            "failed to fetch schema",
+        )
+        .await
+    }
+
+    pub async fn list_tables(
+        &self,
+        database: &str,
+        schema: &str,
+        options: CatalogListOptions,
+    ) -> Result<CatalogPage<TableResourceSummary>, Error> {
+        self.fetch_catalog(
+            &["databases", database, "schemas", schema, "tables"],
+            Some(&options),
+            "failed to list tables",
+        )
+        .await
+    }
+
+    pub async fn fetch_table(
+        &self,
+        database: &str,
+        schema: &str,
+        table: &str,
+    ) -> Result<TableResource, Error> {
+        self.fetch_catalog(
+            &["databases", database, "schemas", schema, "tables", table],
+            None,
+            "failed to fetch table",
+        )
+        .await
+    }
+
+    /// Appends newline-delimited JSON rows to a table.
+    pub async fn append_rows(
+        &self,
+        database: &str,
+        schema: &str,
+        table: &str,
+        ndjson: impl Into<String>,
+    ) -> Result<AppendRowsResult, Error> {
+        let ndjson = ndjson.into();
+        let expected_rows = ndjson
+            .lines()
+            .filter(|line| !line.trim().is_empty())
+            .count();
+        let url = self.make_resource_url(&[
+            "databases",
+            database,
+            "schemas",
+            schema,
+            "tables",
+            table,
+            "rows",
+        ])?;
+        let response = self
+            .client
+            .post(url)
+            .headers(traceparent_headers())
+            .header(reqwest::header::CONTENT_TYPE, "application/x-ndjson")
+            .body(ndjson)
+            .send()
+            .await
+            .map_err(|err| {
+                append_unknown_error("failed to send table append request").set_source(err)
+            })?;
+
+        let status = response.status();
+        let payload = response.bytes().await.map_err(|err| {
+            append_unknown_error("failed to read table append response").set_source(err)
+        })?;
+        let result = decode_append_response(status, &payload)?;
+        if result.num_rows_inserted != expected_rows as i64 {
+            return Err(append_unknown_error(format!(
+                "table append response reported {} inserted rows for a {expected_rows}-row request",
+                result.num_rows_inserted
+            )));
+        }
+        Ok(result)
+    }
+
     pub async fn insert(&self, rows: String, transform: String) -> Result<IngestResult, Error> {
         match self
             .ingest(IngestRequest {
@@ -99,6 +233,28 @@ impl Client {
 }
 
 impl Client {
+    async fn fetch_catalog<T: DeserializeOwned>(
+        &self,
+        segments: &[&str],
+        options: Option<&CatalogListOptions>,
+        operation: &'static str,
+    ) -> Result<T, Error> {
+        let url = self.make_resource_url(segments)?;
+        let mut request = self.client.get(url).headers(traceparent_headers());
+        if let Some(options) = options {
+            request = request.query(options);
+        }
+        let response = request.send().await.map_err(|err| {
+            Error::new(ErrorKind::Unexpected, operation)
+                .set_source(err)
+                .set_temporary()
+        })?;
+        match Response::from_http_response(response).await? {
+            Response::Success(result) => Ok(result),
+            Response::Failed(err) => Err(map_failed_response(err, operation.to_string())),
+        }
+    }
+
     #[fastrace::trace]
     pub(crate) async fn submit_statement(
         &self,
@@ -200,16 +356,201 @@ impl Client {
             Error::new(ErrorKind::Unexpected, "failed to construct URL".to_string()).set_source(err)
         })
     }
+
+    fn make_resource_url(&self, segments: &[&str]) -> Result<Url, Error> {
+        let mut url = self.make_url("v1/")?;
+        let mut path = url.path_segments_mut().map_err(|_| {
+            Error::new(
+                ErrorKind::Unexpected,
+                "endpoint cannot be used as a base URL",
+            )
+        })?;
+        path.pop_if_empty();
+        path.extend(segments.iter().copied());
+        drop(path);
+        Ok(url)
+    }
 }
 
 fn map_failed_response(err: crate::protocol::ErrorStatus, message: String) -> Error {
     let error = Error::new(ErrorKind::Unexpected, format!("{message}: {err}"));
     match err.code() {
-        reqwest::StatusCode::TOO_MANY_REQUESTS
+        reqwest::StatusCode::REQUEST_TIMEOUT
+        | reqwest::StatusCode::TOO_MANY_REQUESTS
         | reqwest::StatusCode::BAD_GATEWAY
         | reqwest::StatusCode::SERVICE_UNAVAILABLE
         | reqwest::StatusCode::GATEWAY_TIMEOUT => error.set_temporary(),
         code if code.is_server_error() => error.set_temporary(),
         _ => error.set_permanent(),
+    }
+}
+
+fn decode_append_response(status: StatusCode, payload: &[u8]) -> Result<AppendRowsResult, Error> {
+    if status == StatusCode::OK {
+        return match serde_json::from_slice::<AppendRowsResult>(payload) {
+            Ok(result)
+                if result.append_state == AppendState::Committed
+                    && result.num_rows_inserted >= 0 =>
+            {
+                Ok(result)
+            }
+            Ok(_) => Err(append_unknown_error(
+                "table append response has an invalid body",
+            )),
+            Err(err) => {
+                Err(append_unknown_error("failed to decode table append response").set_source(err))
+            }
+        };
+    }
+
+    if status.is_success() {
+        return Err(append_unknown_error(format!(
+            "table append returned unexpected success status {}",
+            status.as_u16()
+        )));
+    }
+
+    if let Ok(payload) = serde_json::from_slice::<AppendRowsErrorPayload>(payload) {
+        if matches!(
+            payload.details.append_state,
+            AppendState::Rejected | AppendState::Unknown
+        ) {
+            let append_state = payload.details.append_state;
+            let error = Error::new(
+                ErrorKind::AppendRowsFailed,
+                format_http_error(status, &payload.message),
+            )
+            .set_append_details(payload.details);
+
+            return Err(if append_state == AppendState::Unknown {
+                error.set_persistent()
+            } else if is_temporary_http_status(status) {
+                error.set_temporary()
+            } else {
+                error.set_permanent()
+            });
+        }
+    }
+
+    #[derive(Deserialize)]
+    struct ErrorMessage {
+        message: String,
+    }
+
+    let message = serde_json::from_slice::<ErrorMessage>(payload)
+        .map(|payload| payload.message)
+        .unwrap_or_else(|_| String::from_utf8_lossy(payload).into_owned());
+    Err(append_unknown_error(format_http_error(status, &message)))
+}
+
+fn append_unknown_error(message: impl Into<String>) -> Error {
+    Error::new(ErrorKind::AppendRowsFailed, message)
+        .set_append_details(AppendErrorDetails {
+            append_state: AppendState::Unknown,
+            row_errors: Vec::new(),
+            row_errors_truncated: false,
+        })
+        .set_persistent()
+}
+
+fn is_temporary_http_status(status: StatusCode) -> bool {
+    matches!(
+        status,
+        StatusCode::REQUEST_TIMEOUT | StatusCode::TOO_MANY_REQUESTS
+    ) || status.is_server_error()
+}
+
+fn format_http_error(status: StatusCode, message: &str) -> String {
+    format!(
+        "{} ({}): {}",
+        status.canonical_reason().unwrap_or("Unknown"),
+        status.as_u16(),
+        message
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use reqwest::StatusCode;
+
+    use super::Client;
+    use super::decode_append_response;
+    use crate::ErrorKind;
+    use crate::protocol::AppendState;
+
+    #[test]
+    fn resource_url_preserves_base_path_and_encodes_segments() {
+        let client = Client::new("https://example.com/proxy", reqwest::Client::new()).unwrap();
+
+        let url = client
+            .make_resource_url(&["databases", "analytics/2026", "schemas", "events archive"])
+            .unwrap();
+
+        assert_eq!(
+            url.as_str(),
+            "https://example.com/proxy/v1/databases/analytics%2F2026/schemas/events%20archive"
+        );
+    }
+
+    #[test]
+    fn committed_append_response_is_returned() {
+        let result = decode_append_response(
+            StatusCode::OK,
+            br#"{"append_state":"committed","num_rows_inserted":2}"#,
+        )
+        .unwrap();
+
+        assert_eq!(result.append_state, AppendState::Committed);
+        assert_eq!(result.num_rows_inserted, 2);
+    }
+
+    #[test]
+    fn rejected_append_error_preserves_row_details_and_retry_status() {
+        let error = decode_append_response(
+            StatusCode::SERVICE_UNAVAILABLE,
+            br#"{
+                "message":"validation failed",
+                "append_state":"rejected",
+                "row_errors":[{"row_index":3,"column":"ts","message":"invalid timestamp"}],
+                "row_errors_truncated":true
+            }"#,
+        )
+        .unwrap_err();
+
+        assert_eq!(error.kind(), ErrorKind::AppendRowsFailed);
+        assert!(error.is_temporary());
+        let details = error.append_details().unwrap();
+        assert_eq!(details.append_state, AppendState::Rejected);
+        assert_eq!(details.row_errors[0].row_index, 3);
+        assert!(details.row_errors_truncated);
+    }
+
+    #[test]
+    fn unknown_append_outcome_is_never_retryable() {
+        let error = decode_append_response(
+            StatusCode::SERVICE_UNAVAILABLE,
+            br#"{"message":"coordinator unavailable","append_state":"unknown"}"#,
+        )
+        .unwrap_err();
+
+        assert!(error.is_persistent());
+        assert!(!error.is_temporary());
+        assert_eq!(
+            error.append_details().unwrap().append_state,
+            AppendState::Unknown
+        );
+    }
+
+    #[test]
+    fn unstructured_append_error_is_treated_as_unknown() {
+        let error =
+            decode_append_response(StatusCode::BAD_REQUEST, br#"{"message":"bad request"}"#)
+                .unwrap_err();
+
+        assert!(error.is_persistent());
+        assert_eq!(
+            error.append_details().unwrap().append_state,
+            AppendState::Unknown
+        );
     }
 }

--- a/rust/src/error.rs
+++ b/rust/src/error.rs
@@ -14,6 +14,8 @@
 
 use std::fmt;
 
+use crate::protocol::AppendErrorDetails;
+
 /// ErrorKind is all kinds of Error of ScopeDB client.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[non_exhaustive]
@@ -24,6 +26,9 @@ pub enum ErrorKind {
 
     /// The config for ScopeDB client is invalid.
     ConfigInvalid,
+
+    /// A table append was rejected or its commit outcome is unknown.
+    AppendRowsFailed,
 }
 
 impl ErrorKind {
@@ -44,6 +49,7 @@ impl From<ErrorKind> for &'static str {
         match v {
             ErrorKind::Unexpected => "Unexpected",
             ErrorKind::ConfigInvalid => "ConfigInvalid",
+            ErrorKind::AppendRowsFailed => "AppendRowsFailed",
         }
     }
 }
@@ -86,6 +92,7 @@ pub struct Error {
 
     status: ErrorStatus,
     context: Vec<(&'static str, String)>,
+    append_details: Option<AppendErrorDetails>,
 
     source: Option<anyhow::Error>,
 }
@@ -129,6 +136,7 @@ impl fmt::Debug for Error {
             de.field("message", &self.message);
             de.field("status", &self.status);
             de.field("context", &self.context);
+            de.field("append_details", &self.append_details);
             de.field("source", &self.source);
             return de.finish();
         }
@@ -171,6 +179,7 @@ impl Error {
 
             status: ErrorStatus::Permanent,
             context: Vec::default(),
+            append_details: None,
             source: None,
         }
     }
@@ -190,6 +199,16 @@ impl Error {
         debug_assert!(self.source.is_none(), "the source error has been set");
 
         self.source = Some(src.into());
+        self
+    }
+
+    /// Return structured table-append failure details, when available.
+    pub fn append_details(&self) -> Option<&AppendErrorDetails> {
+        self.append_details.as_ref()
+    }
+
+    pub(crate) fn set_append_details(mut self, details: AppendErrorDetails) -> Self {
+        self.append_details = Some(details);
         self
     }
 
@@ -218,6 +237,11 @@ impl Error {
     /// Return the kind of this error.
     pub fn kind(&self) -> ErrorKind {
         self.kind
+    }
+
+    /// Return the error message.
+    pub fn message(&self) -> &str {
+        &self.message
     }
 
     /// Check if this error is temporary.

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod append_stream;
 mod client;
 mod error;
 mod ingest_stream;
@@ -20,13 +21,36 @@ mod result;
 mod statement;
 mod table;
 
+pub use append_stream::AppendAdmissionResult;
+pub use append_stream::AppendBatchFailureAction;
+pub use append_stream::AppendBatchFailureEvent;
+pub use append_stream::AppendCircuitBreakerOptions;
+pub use append_stream::AppendCircuitState;
+pub use append_stream::AppendDeliveryOutcome;
+pub use append_stream::AppendDeliveryReport;
+pub use append_stream::AppendDroppedRows;
+pub use append_stream::AppendFailurePolicy;
+pub use append_stream::AppendLastFailure;
+pub use append_stream::AppendStream;
+pub use append_stream::AppendStreamBuilder;
+pub use append_stream::AppendStreamState;
+pub use append_stream::AppendStreamStats;
+pub use append_stream::AppendTrySendError;
 pub use client::Client;
 pub use error::Error;
 pub use error::ErrorKind;
 pub use ingest_stream::IngestStream;
 pub use ingest_stream::IngestStreamBuilder;
+pub use protocol::AppendErrorDetails;
+pub use protocol::AppendRowError;
+pub use protocol::AppendRowsResult;
+pub use protocol::AppendState;
+pub use protocol::CatalogListOptions;
+pub use protocol::CatalogPage;
 pub use protocol::DataType;
+pub use protocol::DatabaseResource;
 pub use protocol::IngestResult;
+pub use protocol::SchemaResource;
 pub use protocol::StatementCancelResult;
 pub use protocol::StatementEstimatedProgress;
 pub use protocol::StatementProgress;
@@ -36,6 +60,11 @@ pub use protocol::StatementStatusFailed;
 pub use protocol::StatementStatusFinished;
 pub use protocol::StatementStatusPending;
 pub use protocol::StatementStatusRunning;
+pub use protocol::TableColumnSpec;
+pub use protocol::TableDistinctSpec;
+pub use protocol::TableResource;
+pub use protocol::TableResourceSummary;
+pub use protocol::TableSpec;
 pub use result::FieldSchema;
 pub use result::ResultSet;
 pub use result::Schema;

--- a/rust/src/protocol.rs
+++ b/rust/src/protocol.rs
@@ -26,6 +26,151 @@ use crate::Error;
 use crate::ErrorKind;
 use crate::ResultSet;
 
+/// The commit outcome reported by the table append API.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AppendState {
+    /// Every row in the request was committed.
+    Committed,
+    /// The request was rejected before any row was committed.
+    Rejected,
+    /// The server cannot determine whether the request committed.
+    Unknown,
+}
+
+impl fmt::Display for AppendState {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Committed => f.write_str("committed"),
+            Self::Rejected => f.write_str("rejected"),
+            Self::Unknown => f.write_str("unknown"),
+        }
+    }
+}
+
+/// The result of a committed table append.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AppendRowsResult {
+    pub append_state: AppendState,
+    pub num_rows_inserted: i64,
+}
+
+/// A validation error for one row in an append request.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AppendRowError {
+    pub row_index: u64,
+    pub column: String,
+    pub message: String,
+}
+
+/// Structured failure details returned by the table append API.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AppendErrorDetails {
+    pub append_state: AppendState,
+    #[serde(default)]
+    pub row_errors: Vec<AppendRowError>,
+    #[serde(default)]
+    pub row_errors_truncated: bool,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct AppendRowsErrorPayload {
+    pub message: String,
+    #[serde(flatten)]
+    pub details: AppendErrorDetails,
+}
+
+/// Pagination options for catalog list requests.
+#[derive(Default, Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct CatalogListOptions {
+    /// Number of resources to return. The server accepts values from 1 to 1000.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub page_size: Option<usize>,
+    /// Opaque token returned as `next_page_token` by the previous page.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub page_token: Option<String>,
+}
+
+/// One page of catalog resources.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CatalogPage<T> {
+    pub items: Vec<T>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub next_page_token: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DatabaseResource {
+    pub name: String,
+    pub comment: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SchemaResource {
+    pub database: String,
+    pub name: String,
+    pub comment: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TableResourceSummary {
+    pub database: String,
+    pub schema: String,
+    pub name: String,
+    pub comment: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TableColumnSpec {
+    pub name: String,
+    pub data_type: DataType,
+    pub comment: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TableDistinctSpec {
+    pub on: Vec<String>,
+    pub by: Vec<String>,
+}
+
+/// The public specification of a table resource.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TableSpec {
+    pub columns: Vec<TableColumnSpec>,
+    pub partition_by: Vec<String>,
+    pub cluster_by: Vec<String>,
+    pub distinct_on: TableDistinctSpec,
+    pub data_retention_days: Option<i32>,
+    pub comment: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TableResource {
+    pub database: String,
+    pub schema: String,
+    pub name: String,
+    pub columns: Vec<TableColumnSpec>,
+    pub partition_by: Vec<String>,
+    pub cluster_by: Vec<String>,
+    pub distinct_on: TableDistinctSpec,
+    pub data_retention_days: Option<i32>,
+    pub comment: Option<String>,
+}
+
+impl TableResource {
+    /// Returns the reusable table specification without its catalog identity.
+    pub fn spec(&self) -> TableSpec {
+        TableSpec {
+            columns: self.columns.clone(),
+            partition_by: self.partition_by.clone(),
+            cluster_by: self.cluster_by.clone(),
+            distinct_on: self.distinct_on.clone(),
+            data_retention_days: self.data_retention_days,
+            comment: self.comment.clone(),
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub enum Response<T> {
     Success(T),
@@ -75,8 +220,8 @@ impl fmt::Display for ErrorStatus {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "{:?} ({}): {}",
-            self.code.canonical_reason(),
+            "{} ({}): {}",
+            self.code.canonical_reason().unwrap_or("Unknown"),
             self.code.as_u16(),
             self.message,
         )
@@ -391,5 +536,46 @@ impl FromStr for DataType {
                 format!("unrecognized data type: {s}"),
             )),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::AppendRowsErrorPayload;
+    use super::AppendState;
+    use super::DataType;
+    use super::TableResource;
+
+    #[test]
+    fn append_error_details_use_wire_defaults() {
+        let payload: AppendRowsErrorPayload =
+            serde_json::from_str(r#"{"message":"not committed","append_state":"rejected"}"#)
+                .unwrap();
+
+        assert_eq!(payload.details.append_state, AppendState::Rejected);
+        assert!(payload.details.row_errors.is_empty());
+        assert!(!payload.details.row_errors_truncated);
+    }
+
+    #[test]
+    fn table_resource_deserializes_flattened_spec() {
+        let table: TableResource = serde_json::from_str(
+            r#"{
+                "database":"scopedb",
+                "schema":"public",
+                "name":"events",
+                "columns":[{"name":"message","data_type":"string","comment":null}],
+                "partition_by":["date(ts)"],
+                "cluster_by":["service"],
+                "distinct_on":{"on":[],"by":[]},
+                "data_retention_days":30,
+                "comment":"application events"
+            }"#,
+        )
+        .unwrap();
+
+        assert_eq!(table.name, "events");
+        assert_eq!(table.columns[0].data_type, DataType::String);
+        assert_eq!(table.data_retention_days, Some(30));
     }
 }

--- a/rust/src/table.rs
+++ b/rust/src/table.rs
@@ -12,15 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::str::FromStr;
-
 use crate::Client;
-use crate::DataType;
 use crate::Error;
-use crate::ErrorKind;
 use crate::FieldSchema;
 use crate::Schema;
-use crate::Value;
+use crate::append_stream::AppendStreamBuilder;
+use crate::protocol::AppendRowsResult;
 
 #[derive(Debug, Clone)]
 pub struct Table {
@@ -70,62 +67,45 @@ impl Table {
             .map(|_| ())
     }
 
+    /// Appends newline-delimited JSON rows to this table.
+    pub async fn append(&self, ndjson: impl Into<String>) -> Result<AppendRowsResult, Error> {
+        self.client
+            .append_rows(
+                self.database.as_deref().unwrap_or("scopedb"),
+                self.schema.as_deref().unwrap_or("public"),
+                &self.table,
+                ndjson,
+            )
+            .await
+    }
+
+    /// Builds an asynchronous, bounded and concurrent append stream for this table.
+    pub fn append_stream(&self) -> AppendStreamBuilder {
+        AppendStreamBuilder::new(
+            self.client.clone(),
+            self.database
+                .clone()
+                .unwrap_or_else(|| "scopedb".to_string()),
+            self.schema.clone().unwrap_or_else(|| "public".to_string()),
+            self.table.clone(),
+        )
+    }
+
     pub async fn table_schema(&self) -> Result<Schema, Error> {
         let database_name = self.database.as_deref().unwrap_or("scopedb");
         let schema_name = self.schema.as_deref().unwrap_or("public");
-        let statement = format!(
-            r#"
-            FROM scopedb.system.columns
-            WHERE table_name = {}
-              AND schema_name = {}
-              AND database_name = {}
-            SELECT column_name, data_type
-            "#,
-            quote_string_literal(&self.table),
-            quote_string_literal(schema_name),
-            quote_string_literal(database_name),
-        );
-
-        let rows = self
+        let table = self
             .client
-            .statement(statement)
-            .execute()
-            .await?
-            .into_values()?;
-
-        let mut fields = Vec::with_capacity(rows.len());
-        for row in rows {
-            if row.len() != 2 {
-                return Err(Error::new(
-                    ErrorKind::Unexpected,
-                    format!("expected 2 columns in table schema row, got {}", row.len()),
-                ));
-            }
-
-            let column_name = match &row[0] {
-                Value::String(value) => value.clone(),
-                value => {
-                    return Err(Error::new(
-                        ErrorKind::Unexpected,
-                        format!("expected string column name, got {value:?}"),
-                    ));
-                }
-            };
-            let data_type = match &row[1] {
-                Value::String(value) => DataType::from_str(value)?,
-                value => {
-                    return Err(Error::new(
-                        ErrorKind::Unexpected,
-                        format!("expected string data type, got {value:?}"),
-                    ));
-                }
-            };
-
-            fields.push(FieldSchema {
-                name: column_name,
-                data_type,
-            });
-        }
+            .fetch_table(database_name, schema_name, &self.table)
+            .await?;
+        let fields = table
+            .columns
+            .into_iter()
+            .map(|column| FieldSchema {
+                name: column.name,
+                data_type: column.data_type,
+            })
+            .collect();
 
         Ok(Schema { fields })
     }
@@ -133,10 +113,6 @@ impl Table {
 
 fn quote_ident(input: &str, quote: char) -> String {
     quote_scopeql(input, quote)
-}
-
-fn quote_string_literal(input: &str) -> String {
-    quote_scopeql(input, '\'')
 }
 
 fn quote_scopeql(input: &str, quote: char) -> String {
@@ -163,20 +139,11 @@ fn quote_scopeql(input: &str, quote: char) -> String {
 #[cfg(test)]
 mod tests {
     use super::quote_ident;
-    use super::quote_string_literal;
 
     #[test]
     fn test_quote_ident() {
         assert_eq!(quote_ident("plain", '`'), "`plain`");
         assert_eq!(quote_ident("a`b", '`'), "`a\\`b`");
         assert_eq!(quote_ident("a\nb", '`'), "`a\\nb`");
-    }
-
-    #[test]
-    fn test_quote_string_literal() {
-        assert_eq!(quote_string_literal("plain"), "'plain'");
-        assert_eq!(quote_string_literal("a'b"), "'a\\'b'");
-        assert_eq!(quote_string_literal("a\nb"), "'a\\nb'");
-        assert_eq!(quote_string_literal("a\\b"), "'a\\\\b'");
     }
 }


### PR DESCRIPTION
## Summary

Adds Rust SDK support for read-only REST catalog discovery and NDJSON-only streaming writes. Callers can append one exact NDJSON request directly or use a bounded asynchronous stream that batches rows and sends multiple requests concurrently.

The change also adds delivery reports, strict and best-effort failure policies, retry and unknown-outcome handling, circuit breaking, telemetry and bulk-write examples, API documentation, and Rust CI coverage for the new surface.

## Design Notes

- `send`, `send_all`, and successful `try_send` report local admission; `flush` and `shutdown` are remote settlement barriers.
- Only an exact temporary `rejected` batch is retried. Transport failures, timeouts, and invalid success responses are classified as `unknown` and are not replayed automatically.
- The default `Stop` policy provides a strict accepted-prefix barrier. `Continue` keeps telemetry and logging producers alive while making rejected, ambiguous, and locally dropped rows observable.
- Pending bytes, queue capacity, request concurrency, request size, and row count are bounded.

## Validation

Validated with Rust 1.85 across all targets and features, nightly formatting and Clippy with warnings denied, rustdoc with warnings denied, a crates.io publish dry run, proxy-contaminated loopback tests, and an external consumer against a disposable local ScopeDB table covering catalog reads, direct append, concurrent streaming writes, telemetry mode, and structured rejection errors.