### PR TITLE
test(rust): stabilize append stream mock server

### DIFF
--- a/rust/src/append_stream.rs
+++ b/rust/src/append_stream.rs
@@ -2029,6 +2029,7 @@ mod tests {
         max_active: Arc<AtomicUsize>,
         responder: Arc<Responder>,
     ) {
+        stream.set_nonblocking(false).unwrap();
         stream
             .set_read_timeout(Some(Duration::from_secs(2)))
             .unwrap();
@@ -2107,6 +2108,28 @@ mod tests {
             headers,
             body,
         })
+    }
+
+    #[test]
+    fn mock_server_waits_for_delayed_request_bytes() {
+        let server = MockServer::start(|_, request| MockResponse::committed(request));
+        let mut stream = TcpStream::connect(server.endpoint.trim_start_matches("http://")).unwrap();
+        stream
+            .set_read_timeout(Some(Duration::from_secs(1)))
+            .unwrap();
+
+        thread::sleep(Duration::from_millis(20));
+        let body = "{\"id\":1}\n";
+        let request = format!(
+            "POST /rows HTTP/1.1\r\nHost: localhost\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+            body.len()
+        );
+        stream.write_all(request.as_bytes()).unwrap();
+
+        let mut response = String::new();
+        stream.read_to_string(&mut response).unwrap();
+        assert!(response.starts_with("HTTP/1.1 200 OK"), "{response}");
+        assert_eq!(server.requests().len(), 1);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Makes the append-stream loopback fixture hermetic on Darwin before publishing the Rust SDK release.

The listener is intentionally nonblocking so its accept loop can observe shutdown. On Darwin, accepted sockets inherit that mode; the fixture previously treated an initial `WouldBlock` as EOF and closed the connection, which surfaced intermittently as a client transport failure. Accepted test connections are now returned to blocking mode before request parsing.

A regression test connects first and delays the initial request bytes, proving that the server waits for the request instead of closing the socket.

## Design Notes

This changes test infrastructure only. Production client behavior, NDJSON requests, delivery semantics, and retry policy are unchanged.

## Validation

Validated against the fresh Rust 1.85 dependency resolution with 100 consecutive complete library-test runs, all-target tests, nightly formatting and Clippy with warnings denied, rustdoc with warnings denied, and a crates.io publish dry run.