### PR TITLE
fix(rust): re-export compatible reqwest client

### DIFF
--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -4,6 +4,13 @@ All significant changes to the ScopeDB Rust SDK are documented in this file.
 
 ## Unreleased
 
+## v0.2.1 (2026-08-05)
+
+### Bug Fixes
+
+* Re-exported the SDK's compatible reqwest version and corrected the installation
+  guide so new consumers do not resolve an incompatible reqwest major.
+
 ## v0.2.0 (2026-08-05)
 
 ### Breaking Changes

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "scopedb-client"
-version = "0.2.0"
+version = "0.2.1"
 
 categories = ["database"]
 description = "A Rust client for ScopeDB"

--- a/rust/README.md
+++ b/rust/README.md
@@ -7,21 +7,23 @@ streaming writes, and transform-oriented JSON ingest.
 ## Installation
 
 ```sh
-cargo add scopedb-client reqwest serde_json
+cargo add scopedb-client serde_json
 cargo add tokio --features macros,rt-multi-thread
 ```
 
 ## Create a client
 
-The SDK accepts a configured `reqwest::Client`, so applications can own TLS,
-timeouts, authentication headers, and connection pooling.
+The SDK accepts a configured HTTP client, so applications can own TLS, timeouts,
+authentication headers, and connection pooling. Use the compatible reqwest
+version re-exported as `scopedb_client::reqwest`; a separate direct reqwest
+dependency is not needed.
 
 ```rust
 use scopedb_client::Client;
 
 let client = Client::new(
     "http://127.0.0.1:6543",
-    reqwest::Client::new(),
+    scopedb_client::reqwest::Client::new(),
 )?;
 # Ok::<(), scopedb_client::Error>(())
 ```
@@ -30,7 +32,7 @@ let client = Client::new(
 
 ```rust
 # async fn demo() -> Result<(), scopedb_client::Error> {
-# let client = scopedb_client::Client::new("http://127.0.0.1:6543", reqwest::Client::new())?;
+# let client = scopedb_client::Client::new("http://127.0.0.1:6543", scopedb_client::reqwest::Client::new())?;
 let result = client.statement("SELECT 1".to_string()).execute().await?;
 let rows = result.into_values()?;
 println!("{rows:?}");
@@ -47,7 +49,7 @@ Fetch methods return the full database, schema, or table resource.
 use scopedb_client::CatalogListOptions;
 
 # async fn demo() -> Result<(), scopedb_client::Error> {
-# let client = scopedb_client::Client::new("http://127.0.0.1:6543", reqwest::Client::new())?;
+# let client = scopedb_client::Client::new("http://127.0.0.1:6543", scopedb_client::reqwest::Client::new())?;
 let databases = client
     .list_databases(CatalogListOptions {
         page_size: Some(100),
@@ -91,7 +93,7 @@ Use direct append when the caller already owns one exact NDJSON request boundary
 use scopedb_client::Client;
 
 # async fn demo() -> Result<(), scopedb_client::Error> {
-# let client = Client::new("http://127.0.0.1:6543", reqwest::Client::new())?;
+# let client = Client::new("http://127.0.0.1:6543", scopedb_client::reqwest::Client::new())?;
 let table = client
     .table("events")
     .with_database("scopedb")
@@ -149,7 +151,7 @@ bounded number of HTTP append requests concurrently.
 use std::time::Duration;
 
 # async fn demo() -> Result<(), scopedb_client::Error> {
-# let client = scopedb_client::Client::new("http://127.0.0.1:6543", reqwest::Client::new())?;
+# let client = scopedb_client::Client::new("http://127.0.0.1:6543", scopedb_client::reqwest::Client::new())?;
 let table = client.table("events").with_schema("public");
 let stream = table
     .append_stream()
@@ -204,7 +206,7 @@ use scopedb_client::AppendDeliveryOutcome;
 use scopedb_client::AppendFailurePolicy;
 
 # async fn demo() -> Result<(), scopedb_client::Error> {
-# let client = scopedb_client::Client::new("http://127.0.0.1:6543", reqwest::Client::new())?;
+# let client = scopedb_client::Client::new("http://127.0.0.1:6543", scopedb_client::reqwest::Client::new())?;
 let telemetry = client
     .table("events")
     .append_stream()
@@ -272,7 +274,7 @@ available for reconciliation.
 
 ```rust
 # async fn demo() -> Result<(), scopedb_client::Error> {
-# let client = scopedb_client::Client::new("http://127.0.0.1:6543", reqwest::Client::new())?;
+# let client = scopedb_client::Client::new("http://127.0.0.1:6543", scopedb_client::reqwest::Client::new())?;
 let table = client.table("events").with_schema("public");
 println!("identifier = {}", table.identifier());
 
@@ -290,7 +292,7 @@ match the destination table.
 
 ```rust
 # async fn demo() -> Result<(), scopedb_client::Error> {
-# let client = scopedb_client::Client::new("http://127.0.0.1:6543", reqwest::Client::new())?;
+# let client = scopedb_client::Client::new("http://127.0.0.1:6543", scopedb_client::reqwest::Client::new())?;
 let stream = client
     .ingest_stream(
         r#"

--- a/rust/RELEASE.md
+++ b/rust/RELEASE.md
@@ -10,7 +10,7 @@ version must all match.
    not already present on crates.io:
 
    ```sh
-   export scopedb_rust_version=0.2.0
+   export scopedb_rust_version=0.2.1
    if cargo info "scopedb-client@$scopedb_rust_version" >/dev/null 2>&1; then
      echo "scopedb-client $scopedb_rust_version already exists" >&2
      exit 1
@@ -32,7 +32,7 @@ version must all match.
    test "$(git branch --show-current)" = main
    test -z "$(git status --porcelain)"
    test "$(git rev-parse HEAD)" = "$(git rev-parse origin/main)"
-   export scopedb_rust_version=0.2.0
+   export scopedb_rust_version=0.2.1
    if cargo info "scopedb-client@$scopedb_rust_version" >/dev/null 2>&1; then
      echo "scopedb-client $scopedb_rust_version already exists" >&2
      exit 1

--- a/rust/examples/README.md
+++ b/rust/examples/README.md
@@ -2,6 +2,9 @@
 
 Start with a quickstart, then choose a write pattern whose delivery tradeoffs
 match the workload. Every example uses only the public `scopedb-client` API.
+The shared client helper uses the SDK's compatible HTTP client re-export at
+`scopedb_client::reqwest`, so copied examples do not need a direct reqwest
+dependency.
 
 The commands below run from the [`rust/`](../) directory in a source checkout.
 

--- a/rust/examples/common/mod.rs
+++ b/rust/examples/common/mod.rs
@@ -16,11 +16,12 @@
 
 use std::io;
 
-use reqwest::header::AUTHORIZATION;
-use reqwest::header::HeaderMap;
-use reqwest::header::HeaderValue;
 use scopedb_client::Client;
 use scopedb_client::Table;
+use scopedb_client::reqwest;
+use scopedb_client::reqwest::header::AUTHORIZATION;
+use scopedb_client::reqwest::header::HeaderMap;
+use scopedb_client::reqwest::header::HeaderValue;
 
 pub fn endpoint() -> String {
     std::env::var("SCOPEDB_ENDPOINT").unwrap_or_else(|_| "http://127.0.0.1:6543".to_string())

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -54,6 +54,10 @@ pub struct Client {
 }
 
 impl Client {
+    /// Creates a ScopeDB client from an endpoint and a compatible HTTP client.
+    ///
+    /// Use the HTTP types re-exported from [`crate::reqwest`] to avoid a
+    /// dependency-version mismatch in applications using another reqwest major.
     pub fn new<E: IntoUrl>(endpoint: E, client: reqwest::Client) -> Result<Self, Error> {
         match endpoint.into_url() {
             Ok(mut endpoint) => {

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -65,6 +65,8 @@ pub use protocol::TableDistinctSpec;
 pub use protocol::TableResource;
 pub use protocol::TableResourceSummary;
 pub use protocol::TableSpec;
+/// The HTTP client version used by this SDK.
+pub use reqwest;
 pub use result::FieldSchema;
 pub use result::ResultSet;
 pub use result::Schema;

--- a/rust/tests/public_api.rs
+++ b/rust/tests/public_api.rs
@@ -1,0 +1,22 @@
+// Copyright 2024 ScopeDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[test]
+fn reexported_http_client_matches_constructor() {
+    scopedb_client::Client::new(
+        "http://127.0.0.1:6543",
+        scopedb_client::reqwest::Client::new(),
+    )
+    .unwrap();
+}


### PR DESCRIPTION
## Summary

Prepares the Rust SDK 0.2.1 compatibility hotfix after a fresh external consumer exposed an installation mismatch in 0.2.0.

`Client::new` accepts reqwest 0.12 types, but the README's unversioned direct dependency command now resolves reqwest 0.13. This change re-exports the SDK's compatible HTTP client as `scopedb_client::reqwest`, removes the unnecessary direct reqwest installation step, and updates the packaged README and examples to use the re-export.

## Design Notes

The existing constructor signature already makes reqwest a public dependency. Re-exporting that exact version is additive and semver-compatible, avoids a second direct dependency for new consumers, and lets applications that use reqwest 0.13 elsewhere keep both majors without ambiguity. The runtime client, request behavior, and delivery semantics are unchanged.

## Validation

Validated with Rust 1.85 across all targets and features, nightly formatting and Clippy with warnings denied, rustdoc with warnings denied, a publish dry run, and an integration test for the public re-export. Separate fresh consumers passed both without a direct reqwest dependency and with an application-owned reqwest 0.13 alongside the SDK's re-export.