### PR TITLE
fix(rust): pass through API errors

### DIFF
--- a/docs/rust-http-api.md
+++ b/docs/rust-http-api.md
@@ -4,16 +4,6 @@ This document describes the HTTP surface modeled by the Rust SDK and the
 delivery rules that its higher-level helpers preserve. Public endpoints are
 rooted at `/v1`.
 
-## Health
-
-### `GET /v1/health`
-
-Returns a plain-text connectivity and liveness response:
-
-```text
-OK
-```
-
 ## REST catalog API
 
 Catalog endpoints are read-only. Every user-provided database, schema, and

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -4,6 +4,17 @@ All significant changes to the ScopeDB Rust SDK are documented in this file.
 
 ## Unreleased
 
+### Bug Fixes
+
+* Return an error when the health endpoint responds with a non-success status.
+* Decode error messages from both direct server responses and nested cloud proxy
+  error envelopes, including unknown-outcome append failures.
+
+### Documentation
+
+* Prefer `SCOPEDB_API_KEY` in examples while retaining `SCOPEDB_TOKEN` as a
+  backward-compatible fallback, and mark authorization headers as sensitive.
+
 ## v0.2.1 (2026-08-05)
 
 ### Bug Fixes

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -7,8 +7,8 @@ All significant changes to the ScopeDB Rust SDK are documented in this file.
 ### Bug Fixes
 
 * Return an error when the health endpoint responds with a non-success status.
-* Decode error messages from both direct server responses and nested cloud proxy
-  error envelopes, including unknown-outcome append failures.
+* Decode error messages from both direct and nested API error envelopes,
+  including unknown-outcome append failures.
 
 ### Documentation
 

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -6,7 +6,8 @@ All significant changes to the ScopeDB Rust SDK are documented in this file.
 
 ### Bug Fixes
 
-* Return an error when the health endpoint responds with a non-success status.
+* Removed `Client::health_check`, which targeted an internal liveness endpoint
+  and could report non-success HTTP responses as healthy.
 * Decode error messages from both direct and nested API error envelopes,
   including unknown-outcome append failures.
 

--- a/rust/README.md
+++ b/rust/README.md
@@ -28,6 +28,12 @@ let client = Client::new(
 # Ok::<(), scopedb_client::Error>(())
 ```
 
+The runnable examples read authentication from `SCOPEDB_API_KEY`. For backward
+compatibility, they fall back to `SCOPEDB_TOKEN` when the API key variable is
+unset or empty. The shared helper marks the resulting authorization header as
+sensitive so standard header and request `Debug` formatting redacts the
+credential.
+
 ## Run a statement
 
 ```rust

--- a/rust/examples/README.md
+++ b/rust/examples/README.md
@@ -40,7 +40,8 @@ CREATE TABLE public.sdk_example_events (
 Configuration comes from:
 
 - `SCOPEDB_ENDPOINT` (defaults to `http://127.0.0.1:6543`)
-- `SCOPEDB_TOKEN` (optional Bearer token)
+- `SCOPEDB_API_KEY` (optional Bearer API key; preferred)
+- `SCOPEDB_TOKEN` (fallback when `SCOPEDB_API_KEY` is unset or empty)
 - `SCOPEDB_DATABASE` (defaults to `scopedb`)
 - `SCOPEDB_SCHEMA` (defaults to `public`)
 - `SCOPEDB_TABLE` (required for writes)

--- a/rust/examples/common/mod.rs
+++ b/rust/examples/common/mod.rs
@@ -37,13 +37,18 @@ pub fn schema() -> String {
 
 pub fn client() -> Result<Client, Box<dyn std::error::Error>> {
     let mut headers = HeaderMap::new();
-    if let Ok(token) = std::env::var("SCOPEDB_TOKEN") {
-        if !token.is_empty() {
-            headers.insert(
-                AUTHORIZATION,
-                HeaderValue::from_str(&format!("Bearer {token}"))?,
-            );
-        }
+    let token = std::env::var("SCOPEDB_API_KEY")
+        .ok()
+        .filter(|value| !value.is_empty())
+        .or_else(|| {
+            std::env::var("SCOPEDB_TOKEN")
+                .ok()
+                .filter(|value| !value.is_empty())
+        });
+    if let Some(token) = token {
+        let mut authorization = HeaderValue::from_str(&format!("Bearer {token}"))?;
+        authorization.set_sensitive(true);
+        headers.insert(AUTHORIZATION, authorization);
     }
 
     let http_client = reqwest::Client::builder()

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -535,7 +535,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn health_check_rejects_proxy_error_status() {
+    async fn health_check_rejects_nested_error_status() {
         let body = r#"{"error":{"message":"unsupported path"}}"#;
         let (endpoint, server) = serve_once("404 Not Found", body);
         let client = loopback_client(endpoint);
@@ -650,7 +650,7 @@ mod tests {
     }
 
     #[test]
-    fn proxy_append_error_has_clean_message_and_unknown_outcome() {
+    fn nested_append_error_has_clean_message_and_unknown_outcome() {
         let error = decode_append_response(
             StatusCode::NOT_FOUND,
             br#"{"error":{"message":"unsupported path"}}"#,

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -91,35 +91,6 @@ impl Client {
         IngestStreamBuilder::new(self.clone(), statement.into())
     }
 
-    pub async fn health_check(&self) -> Result<(), Error> {
-        let url = self.make_url("v1/health")?;
-        let response = self.client.get(url).send().await.map_err(|err| {
-            Error::new(
-                ErrorKind::Unexpected,
-                "failed to send health check request".to_string(),
-            )
-            .set_source(err)
-            .set_temporary()
-        })?;
-        let status = response.status();
-        if status.is_success() {
-            return Ok(());
-        }
-
-        let payload = response.bytes().await.map_err(|err| {
-            Error::new(
-                ErrorKind::Unexpected,
-                "failed to read health check response".to_string(),
-            )
-            .set_source(err)
-            .set_temporary()
-        })?;
-        Err(map_failed_response(
-            crate::protocol::ErrorStatus::from_http_payload(status, &payload),
-            "health check failed".to_string(),
-        ))
-    }
-
     pub async fn list_databases(
         &self,
         options: CatalogListOptions,
@@ -485,40 +456,12 @@ fn format_http_error(status: StatusCode, message: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use std::io::Read;
-    use std::io::Write;
-    use std::net::TcpListener;
-    use std::thread;
-
     use reqwest::StatusCode;
 
     use super::Client;
     use super::decode_append_response;
     use crate::ErrorKind;
     use crate::protocol::AppendState;
-
-    fn serve_once(status: &'static str, body: &'static str) -> (String, thread::JoinHandle<()>) {
-        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
-        let address = listener.local_addr().unwrap();
-        let server = thread::spawn(move || {
-            let (mut stream, _) = listener.accept().unwrap();
-            let mut request = [0; 1024];
-            let request_len = stream.read(&mut request).unwrap();
-            assert!(request_len > 0);
-            write!(
-                stream,
-                "HTTP/1.1 {status}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
-                body.len()
-            )
-            .unwrap();
-        });
-        (format!("http://{address}"), server)
-    }
-
-    fn loopback_client(endpoint: String) -> Client {
-        let http_client = reqwest::Client::builder().no_proxy().build().unwrap();
-        Client::new(endpoint, http_client).unwrap()
-    }
 
     #[test]
     fn resource_url_preserves_base_path_and_encodes_segments() {
@@ -532,59 +475,6 @@ mod tests {
             url.as_str(),
             "https://example.com/proxy/v1/databases/analytics%2F2026/schemas/events%20archive"
         );
-    }
-
-    #[tokio::test]
-    async fn health_check_rejects_nested_error_status() {
-        let body = r#"{"error":{"message":"unsupported path"}}"#;
-        let (endpoint, server) = serve_once("404 Not Found", body);
-        let client = loopback_client(endpoint);
-
-        let error = client.health_check().await.unwrap_err();
-        server.join().unwrap();
-
-        assert_eq!(error.kind(), ErrorKind::Unexpected);
-        assert!(error.is_permanent());
-        assert_eq!(
-            error.message(),
-            "health check failed: Not Found (404): unsupported path"
-        );
-    }
-
-    #[tokio::test]
-    async fn health_check_marks_service_unavailable_as_temporary() {
-        let body = r#"{"error":{"message":"try again later"}}"#;
-        let (endpoint, server) = serve_once("503 Service Unavailable", body);
-        let client = loopback_client(endpoint);
-
-        let error = client.health_check().await.unwrap_err();
-        server.join().unwrap();
-
-        assert!(error.is_temporary());
-        assert_eq!(
-            error.message(),
-            "health check failed: Service Unavailable (503): try again later"
-        );
-    }
-
-    #[tokio::test]
-    async fn health_check_marks_transport_failure_as_temporary() {
-        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
-        let address = listener.local_addr().unwrap();
-        let server = thread::spawn(move || {
-            let (mut stream, _) = listener.accept().unwrap();
-            let mut request = [0; 1024];
-            let request_len = stream.read(&mut request).unwrap();
-            assert!(request_len > 0);
-            // Close the connection without sending an HTTP response.
-        });
-        let client = loopback_client(format!("http://{address}"));
-
-        let error = client.health_check().await.unwrap_err();
-        server.join().unwrap();
-
-        assert!(error.is_temporary());
-        assert_eq!(error.message(), "failed to send health check request");
     }
 
     #[test]

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -16,7 +16,6 @@ use fastrace_reqwest::traceparent_headers;
 use reqwest::IntoUrl;
 use reqwest::StatusCode;
 use reqwest::Url;
-use serde::Deserialize;
 use serde::de::DeserializeOwned;
 use uuid::Uuid;
 
@@ -45,6 +44,7 @@ use crate::protocol::StatementRequestParams;
 use crate::protocol::StatementStatus;
 use crate::protocol::TableResource;
 use crate::protocol::TableResourceSummary;
+use crate::protocol::http_error_message;
 use crate::statement::StatementHandle;
 
 #[derive(Debug, Clone)]
@@ -93,14 +93,31 @@ impl Client {
 
     pub async fn health_check(&self) -> Result<(), Error> {
         let url = self.make_url("v1/health")?;
-        self.client.get(url).send().await.map_err(|err| {
+        let response = self.client.get(url).send().await.map_err(|err| {
             Error::new(
                 ErrorKind::Unexpected,
                 "failed to send health check request".to_string(),
             )
             .set_source(err)
+            .set_temporary()
         })?;
-        Ok(())
+        let status = response.status();
+        if status.is_success() {
+            return Ok(());
+        }
+
+        let payload = response.bytes().await.map_err(|err| {
+            Error::new(
+                ErrorKind::Unexpected,
+                "failed to read health check response".to_string(),
+            )
+            .set_source(err)
+            .set_temporary()
+        })?;
+        Err(map_failed_response(
+            crate::protocol::ErrorStatus::from_http_payload(status, &payload),
+            "health check failed".to_string(),
+        ))
     }
 
     pub async fn list_databases(
@@ -436,14 +453,7 @@ fn decode_append_response(status: StatusCode, payload: &[u8]) -> Result<AppendRo
         }
     }
 
-    #[derive(Deserialize)]
-    struct ErrorMessage {
-        message: String,
-    }
-
-    let message = serde_json::from_slice::<ErrorMessage>(payload)
-        .map(|payload| payload.message)
-        .unwrap_or_else(|_| String::from_utf8_lossy(payload).into_owned());
+    let message = http_error_message(payload);
     Err(append_unknown_error(format_http_error(status, &message)))
 }
 
@@ -475,12 +485,40 @@ fn format_http_error(status: StatusCode, message: &str) -> String {
 
 #[cfg(test)]
 mod tests {
+    use std::io::Read;
+    use std::io::Write;
+    use std::net::TcpListener;
+    use std::thread;
+
     use reqwest::StatusCode;
 
     use super::Client;
     use super::decode_append_response;
     use crate::ErrorKind;
     use crate::protocol::AppendState;
+
+    fn serve_once(status: &'static str, body: &'static str) -> (String, thread::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = [0; 1024];
+            let request_len = stream.read(&mut request).unwrap();
+            assert!(request_len > 0);
+            write!(
+                stream,
+                "HTTP/1.1 {status}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len()
+            )
+            .unwrap();
+        });
+        (format!("http://{address}"), server)
+    }
+
+    fn loopback_client(endpoint: String) -> Client {
+        let http_client = reqwest::Client::builder().no_proxy().build().unwrap();
+        Client::new(endpoint, http_client).unwrap()
+    }
 
     #[test]
     fn resource_url_preserves_base_path_and_encodes_segments() {
@@ -494,6 +532,59 @@ mod tests {
             url.as_str(),
             "https://example.com/proxy/v1/databases/analytics%2F2026/schemas/events%20archive"
         );
+    }
+
+    #[tokio::test]
+    async fn health_check_rejects_proxy_error_status() {
+        let body = r#"{"error":{"message":"unsupported path"}}"#;
+        let (endpoint, server) = serve_once("404 Not Found", body);
+        let client = loopback_client(endpoint);
+
+        let error = client.health_check().await.unwrap_err();
+        server.join().unwrap();
+
+        assert_eq!(error.kind(), ErrorKind::Unexpected);
+        assert!(error.is_permanent());
+        assert_eq!(
+            error.message(),
+            "health check failed: Not Found (404): unsupported path"
+        );
+    }
+
+    #[tokio::test]
+    async fn health_check_marks_service_unavailable_as_temporary() {
+        let body = r#"{"error":{"message":"try again later"}}"#;
+        let (endpoint, server) = serve_once("503 Service Unavailable", body);
+        let client = loopback_client(endpoint);
+
+        let error = client.health_check().await.unwrap_err();
+        server.join().unwrap();
+
+        assert!(error.is_temporary());
+        assert_eq!(
+            error.message(),
+            "health check failed: Service Unavailable (503): try again later"
+        );
+    }
+
+    #[tokio::test]
+    async fn health_check_marks_transport_failure_as_temporary() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = [0; 1024];
+            let request_len = stream.read(&mut request).unwrap();
+            assert!(request_len > 0);
+            // Close the connection without sending an HTTP response.
+        });
+        let client = loopback_client(format!("http://{address}"));
+
+        let error = client.health_check().await.unwrap_err();
+        server.join().unwrap();
+
+        assert!(error.is_temporary());
+        assert_eq!(error.message(), "failed to send health check request");
     }
 
     #[test]
@@ -551,6 +642,22 @@ mod tests {
             decode_append_response(StatusCode::BAD_REQUEST, br#"{"message":"bad request"}"#)
                 .unwrap_err();
 
+        assert!(error.is_persistent());
+        assert_eq!(
+            error.append_details().unwrap().append_state,
+            AppendState::Unknown
+        );
+    }
+
+    #[test]
+    fn proxy_append_error_has_clean_message_and_unknown_outcome() {
+        let error = decode_append_response(
+            StatusCode::NOT_FOUND,
+            br#"{"error":{"message":"unsupported path"}}"#,
+        )
+        .unwrap_err();
+
+        assert_eq!(error.message(), "Not Found (404): unsupported path");
         assert!(error.is_persistent());
         assert_eq!(
             error.append_details().unwrap().append_state,

--- a/rust/src/protocol.rs
+++ b/rust/src/protocol.rs
@@ -577,14 +577,14 @@ mod tests {
     }
 
     #[test]
-    fn http_error_message_supports_direct_and_proxy_payloads() {
+    fn http_error_message_supports_direct_and_nested_payloads() {
         assert_eq!(
             http_error_message(br#"{"message":"direct failure","error":"details"}"#),
             "direct failure"
         );
         assert_eq!(
-            http_error_message(br#"{"error":{"message":"proxy failure"}}"#),
-            "proxy failure"
+            http_error_message(br#"{"error":{"message":"nested failure"}}"#),
+            "nested failure"
         );
     }
 

--- a/rust/src/protocol.rs
+++ b/rust/src/protocol.rs
@@ -189,18 +189,10 @@ impl<T: DeserializeOwned> Response<T> {
             return Ok(Response::Success(result));
         }
 
-        #[derive(Deserialize)]
-        struct ErrorMessage {
-            message: String,
-        }
-
         let payload = r.bytes().await.map_err(make_error)?;
-        if let Ok(ErrorMessage { message }) = serde_json::from_slice::<ErrorMessage>(&payload) {
-            Ok(Response::Failed(ErrorStatus { code, message }))
-        } else {
-            let message = String::from_utf8_lossy(&payload).into_owned();
-            Ok(Response::Failed(ErrorStatus { code, message }))
-        }
+        Ok(Response::Failed(ErrorStatus::from_http_payload(
+            code, &payload,
+        )))
     }
 }
 
@@ -211,9 +203,35 @@ pub struct ErrorStatus {
 }
 
 impl ErrorStatus {
+    pub(crate) fn from_http_payload(code: StatusCode, payload: &[u8]) -> Self {
+        Self {
+            code,
+            message: http_error_message(payload),
+        }
+    }
+
     pub fn code(&self) -> StatusCode {
         self.code
     }
+}
+
+pub(crate) fn http_error_message(payload: &[u8]) -> String {
+    if let Ok(payload) = serde_json::from_slice::<serde_json::Value>(payload) {
+        let message = payload
+            .get("message")
+            .and_then(serde_json::Value::as_str)
+            .or_else(|| {
+                payload
+                    .get("error")
+                    .and_then(|error| error.get("message"))
+                    .and_then(serde_json::Value::as_str)
+            });
+        if let Some(message) = message {
+            return message.to_string();
+        }
+    }
+
+    String::from_utf8_lossy(payload).into_owned()
 }
 
 impl fmt::Display for ErrorStatus {
@@ -545,6 +563,7 @@ mod tests {
     use super::AppendState;
     use super::DataType;
     use super::TableResource;
+    use super::http_error_message;
 
     #[test]
     fn append_error_details_use_wire_defaults() {
@@ -555,6 +574,18 @@ mod tests {
         assert_eq!(payload.details.append_state, AppendState::Rejected);
         assert!(payload.details.row_errors.is_empty());
         assert!(!payload.details.row_errors_truncated);
+    }
+
+    #[test]
+    fn http_error_message_supports_direct_and_proxy_payloads() {
+        assert_eq!(
+            http_error_message(br#"{"message":"direct failure","error":"details"}"#),
+            "direct failure"
+        );
+        assert_eq!(
+            http_error_message(br#"{"error":{"message":"proxy failure"}}"#),
+            "proxy failure"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What changed

- Remove `Client::health_check()` and the public health documentation because the liveness endpoint is internal and is not a supported SDK API.
- Pass through server-provided error messages from both direct `{"message": ...}` responses and nested `{"error":{"message": ...}}` API error envelopes.
- Preserve append safety: a non-success response without an explicit append outcome remains a persistent `AppendState::Unknown`, so the SDK never retries an ambiguous write automatically.
- Prefer `SCOPEDB_API_KEY` in runnable examples, retain `SCOPEDB_TOKEN` as a compatibility fallback, and mark the Authorization header sensitive for standard Debug formatting.

## Why

The SDK exposed an unsupported health method whose implementation discarded the HTTP status, allowing a response such as 404 to be reported as healthy. API failures could also surface as raw JSON instead of the server-provided message, and the examples used a different authentication environment variable from the integration workflow.

## Impact

The unsupported `Client::health_check()` method is removed. Other callers receive actionable server error messages while retaining the existing retry classification and append delivery guarantees. Streaming writes continue to fail closed when the write outcome is ambiguous.

## Validation

- `just check`
- `cargo +nightly fmt --all -- --check`
- `cargo +nightly clippy --locked --tests --all-targets --all-features -- -D warnings`
- `cargo +1.85.0 test --locked --all-targets --all-features`
- `RUSTDOCFLAGS='-D warnings' cargo +1.85.0 doc --locked --no-deps --all-features`
- Live catalog, direct NDJSON append, append stream, query readback, error handling, and cleanup smoke tests
