### PR TITLE
feat(rust)!: align application-facing SDK capabilities

### DIFF
--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Install MSRV toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.85.0
+          toolchain: 1.91.0
       - uses: taiki-e/install-action@just
       - name: Run full tests
         timeout-minutes: 10

--- a/docs/rust-http-api.md
+++ b/docs/rust-http-api.md
@@ -50,6 +50,11 @@ shape for every resource type:
 `next_page_token` is omitted when there is no next page. Clients must pass it
 back unchanged and must not parse or synthesize it.
 
+`Client::iterate_databases`, `iterate_schemas`, and `iterate_tables` follow the
+token automatically, fetch pages lazily, and reject a repeated token instead of
+looping forever. The `list_*` methods expose one explicit page when an
+application needs page boundaries.
+
 ### Resource shapes
 
 Database:
@@ -194,11 +199,14 @@ it is not a separate HTTP endpoint.
 - Every accepted Rust value is serialized to exactly one NDJSON line.
 - `send` and `send_all` wait for local admission capacity, not a remote commit.
 - `try_send` attempts local admission immediately.
-- Size and time thresholds seal batches.
-- `max_in_flight_requests` bounds concurrent append requests.
-- `max_pending_bytes` bounds accepted serialized data that has not settled.
+- `target_batch_bytes`, `max_batch_rows`, and the flush interval seal batches.
+- `max_concurrent_batches` bounds concurrent append requests.
+- `max_buffered_bytes` bounds accepted serialized data that has not settled.
 - `flush` settles all rows accepted before its barrier.
 - `shutdown` closes admission and settles the final accepted prefix.
+
+The older `batch_bytes`, `max_in_flight_requests`, and `max_pending_bytes`
+builder names remain source-compatible deprecated aliases.
 
 With the default `Stop` failure policy, a failed batch makes the stream terminal
 and barriers return an error. With `Continue`, rejected and unknown batches are
@@ -240,7 +248,10 @@ in-band states, so HTTP success does not imply statement success.
 ### `GET /v1/statements/{statement_id}?format=json`
 
 Fetches the latest state for a submitted statement and returns the same state
-payload family as statement submission.
+payload family as statement submission. `StatementHandle::refresh` performs one
+fetch; `StatementHandle::wait` polls with bounded exponential delay until a
+terminal state. The older `fetch_once` and `fetch` names remain deprecated
+aliases.
 
 ### `POST /v1/statements/{statement_id}/cancel`
 
@@ -319,3 +330,11 @@ Non-append non-2xx responses generally use:
 
 The SDK distinguishes transport or deserialization errors, non-2xx server
 errors, structured append outcomes, and in-band statement terminal states.
+Server messages remain unchanged in `Error::message()`. When available,
+`http_status()`, `request_id()`, and `retry_after()` expose response metadata;
+`is_retryable()` includes an explicit `retryable` value from direct or nested
+error envelopes before falling back to HTTP status classification.
+
+`Retry-After` accepts delta seconds and HTTP dates. Streaming writes use it only
+for a temporary append explicitly reported as `rejected`, and cap the delay at
+the configured maximum backoff. Unknown append outcomes are never retried.

--- a/docs/rust-http-api.md
+++ b/docs/rust-http-api.md
@@ -248,10 +248,12 @@ in-band states, so HTTP success does not imply statement success.
 ### `GET /v1/statements/{statement_id}?format=json`
 
 Fetches the latest state for a submitted statement and returns the same state
-payload family as statement submission. `StatementHandle::refresh` performs one
-fetch; `StatementHandle::wait` polls with bounded exponential delay until a
+payload family as statement submission. `StatementHandle::status().await`
+performs at most one fetch and updates the snapshot returned by
+`StatementHandle::last_status`; terminal snapshots are returned without another
+request. `StatementHandle::wait` polls with bounded exponential delay until a
 terminal state. The older `fetch_once` and `fetch` names remain deprecated
-aliases.
+aliases for `status` and `wait`, respectively.
 
 ### `POST /v1/statements/{statement_id}/cancel`
 

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -4,6 +4,32 @@ All significant changes to the ScopeDB Rust SDK are documented in this file.
 
 ## Unreleased
 
+### New Features
+
+* Added an API-key client builder, `Client::query`, full table descriptions,
+  lazy catalog iterators, and `StatementHandle::refresh` / `wait` application
+  paths while retaining the existing lower-level APIs.
+* Added raw, typed-value, keyed-object, and first-row result conversions.
+  Object conversion rejects duplicate output column names instead of silently
+  dropping a value.
+* Added streaming-write builder names centered on batches and buffering, plus a
+  configurable `max_batch_rows` below the protocol ceiling. Existing builder
+  names remain compatible deprecated aliases.
+
+### Reliability
+
+* Preserve HTTP status, request ID, `Retry-After`, and explicit server retry
+  classification on errors while keeping server messages unchanged.
+* Honor delta-seconds and HTTP-date `Retry-After` values for safe rejected-batch
+  retries, capped by the configured maximum backoff.
+* Return typed errors instead of panicking when result metadata and row shapes
+  disagree, and reject repeated catalog page tokens.
+
+### Documentation
+
+* Reworked runnable examples around read-only discovery, direct append,
+  asynchronous batching, bulk imports, and best-effort telemetry journeys.
+
 ## v0.2.2 (2026-08-05)
 
 ### Bug Fixes

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -9,12 +9,17 @@ All significant changes to the ScopeDB Rust SDK are documented in this file.
 * Raised the minimum supported Rust version from 1.85.0 to 1.91.0 so fresh
   consumers can resolve the current dependency graph without an inherited
   lockfile.
+* Renamed the synchronous `StatementHandle::status()` snapshot accessor to
+  `last_status()` and use the asynchronous `status().await` operation for one
+  remote status check. The previous synchronous name cannot remain as an alias
+  because Rust does not support overloading it with the asynchronous operation.
 
 ### New Features
 
 * Added an API-key client builder, `Client::query`, full table descriptions,
-  lazy catalog iterators, and `StatementHandle::refresh` / `wait` application
-  paths while retaining the existing lower-level APIs.
+  lazy catalog iterators, and `StatementHandle::status` / `wait` application
+  paths. The released `fetch_once` and `fetch` methods remain as deprecated
+  aliases for `status` and `wait`.
 * Added raw, typed-value, keyed-object, and first-row result conversions.
   Object conversion rejects duplicate output column names instead of silently
   dropping a value.

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -4,6 +4,12 @@ All significant changes to the ScopeDB Rust SDK are documented in this file.
 
 ## Unreleased
 
+### Breaking Changes
+
+* Raised the minimum supported Rust version from 1.85.0 to 1.91.0 so fresh
+  consumers can resolve the current dependency graph without an inherited
+  lockfile.
+
 ### New Features
 
 * Added an API-key client builder, `Client::query`, full table descriptions,

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -24,7 +24,7 @@ documentation = "https://docs.rs/scopedb-client"
 edition = "2024"
 homepage = "https://www.scopedb.io"
 license = "Apache-2.0"
-rust-version = "1.85.0"
+rust-version = "1.91.0"
 repository = "https://github.com/scopedb/scopedb-sdk"
 
 [dependencies]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -32,6 +32,7 @@ anyhow = { version = "1.0.99" }
 fastrace = { version = "0.7" }
 fastrace-reqwest = { version = "0.2" }
 hex = { version = "0.4" }
+httpdate = { version = "1" }
 jiff = { version = "0.2", features = ["serde"] }
 mea = { version = "0.6.3" }
 reqwest = { version = "0.12", default-features = false, features = [

--- a/rust/README.md
+++ b/rust/README.md
@@ -6,6 +6,8 @@ streaming writes, and transform-oriented JSON ingest.
 
 ## Installation
 
+`scopedb-client` requires Rust 1.91.0 or later.
+
 ```sh
 cargo add scopedb-client serde_json
 cargo add tokio --features macros,rt-multi-thread

--- a/rust/README.md
+++ b/rust/README.md
@@ -13,24 +13,28 @@ cargo add tokio --features macros,rt-multi-thread
 
 ## Create a client
 
-The SDK accepts a configured HTTP client, so applications can own TLS, timeouts,
-authentication headers, and connection pooling. Use the compatible reqwest
-version re-exported as `scopedb_client::reqwest`; a separate direct reqwest
-dependency is not needed.
+Use the builder for the common API-key path. An API key is a server credential:
+keep it in a trusted process and never compile or return it to an untrusted
+client.
 
 ```rust
 use scopedb_client::Client;
 
-let client = Client::new(
-    "http://127.0.0.1:6543",
-    scopedb_client::reqwest::Client::new(),
-)?;
+let client = Client::builder("http://127.0.0.1:6543")
+    .api_key(std::env::var("SCOPEDB_API_KEY").expect("SCOPEDB_API_KEY is required"))
+    .build()?;
 # Ok::<(), scopedb_client::Error>(())
 ```
 
+Applications that own TLS, proxy, timeout, or pooling settings can pass a
+compatible HTTP client through `.http_client(...)`. `Client::new(endpoint,
+http_client)` remains available when authentication is already configured on
+that client. Use the reqwest version re-exported as `scopedb_client::reqwest` to
+avoid dependency-version mismatches.
+
 The runnable examples read authentication from `SCOPEDB_API_KEY`. For backward
 compatibility, they fall back to `SCOPEDB_TOKEN` when the API key variable is
-unset or empty. The shared helper marks the resulting authorization header as
+unset or empty. The builder marks the resulting authorization header as
 sensitive so standard header and request `Debug` formatting redacts the
 credential.
 
@@ -48,44 +52,52 @@ separately. Use these canonical entry points:
 ```rust
 # async fn demo() -> Result<(), scopedb_client::Error> {
 # let client = scopedb_client::Client::new("http://127.0.0.1:6543", scopedb_client::reqwest::Client::new())?;
-let result = client.statement("SELECT 1".to_string()).execute().await?;
-let rows = result.into_values()?;
+let result = client.query("SELECT 1 AS ready").await?;
+let rows = result.into_objects()?;
 println!("{rows:?}");
 # Ok(())
 # }
 ```
 
+`raw_rows()` exposes the string-or-null wire cells without parsing.
+`to_values()` borrows the result while `into_values()` consumes it and moves
+owned string cells. `to_objects()` and `into_objects()` key values by output
+column name; they return an error when names are duplicated, so use the value
+form for intentionally duplicated columns. `first()` converts only the first
+row for point lookups and aggregates.
+
+For lifecycle control, call `client.statement(scopeql).submit()` and retain the
+returned handle. `refresh()` fetches one status snapshot, `wait()` polls to a
+terminal result, and `cancel()` requests cancellation. The statement ID is
+available immediately after submission.
+
 ## Browse the catalog
 
-Catalog list methods return one page and preserve the opaque continuation token.
-Fetch methods return the full database, schema, or table resource.
+Catalog iterators follow opaque continuation tokens automatically and fetch the
+next page only when needed. List methods remain available when the application
+needs explicit page boundaries; fetch methods return one full resource.
 
 ```rust
 use scopedb_client::CatalogListOptions;
 
 # async fn demo() -> Result<(), scopedb_client::Error> {
 # let client = scopedb_client::Client::new("http://127.0.0.1:6543", scopedb_client::reqwest::Client::new())?;
-let databases = client
-    .list_databases(CatalogListOptions {
+let mut databases = client
+    .iterate_databases(CatalogListOptions {
         page_size: Some(100),
         page_token: None,
-    })
-    .await?;
+    });
+while let Some(database) = databases.next().await? {
+    println!("database = {}", database.name);
+}
 
 let database = client.fetch_database("scopedb").await?;
-let schemas = client
-    .list_schemas("scopedb", CatalogListOptions::default())
-    .await?;
 let schema = client.fetch_schema("scopedb", "public").await?;
-let tables = client
-    .list_tables("scopedb", "public", CatalogListOptions::default())
-    .await?;
 let table = client
     .fetch_table("scopedb", "public", "events")
     .await?;
 
 println!("{} {} {}", database.name, schema.name, table.name);
-println!("first page: {} databases, {} schemas, {} tables", databases.items.len(), schemas.items.len(), tables.items.len());
 # Ok(())
 # }
 ```
@@ -156,6 +168,23 @@ if error.kind() == ErrorKind::AppendRowsFailed {
 `Unknown` is deliberately different from a rejection: replaying the same rows
 may insert duplicates.
 
+All HTTP errors preserve the server message in `Error::message()` and expose
+operational metadata without message parsing:
+
+```rust
+# fn inspect(error: &scopedb_client::Error) {
+eprintln!("{}", error.message());
+eprintln!("status = {:?}", error.http_status());
+eprintln!("request_id = {:?}", error.request_id());
+eprintln!("retryable = {}", error.is_retryable());
+eprintln!("retry_after = {:?}", error.retry_after());
+# }
+```
+
+The asynchronous append stream honors `Retry-After` only for an exact temporary
+batch explicitly reported as `Rejected`; the delay is capped by `max_backoff`.
+Unknown outcomes remain non-retryable because replay can duplicate rows.
+
 ### Asynchronous append stream
 
 Use `append_stream()` for continuous or large producers. The stream serializes
@@ -170,10 +199,11 @@ use std::time::Duration;
 let table = client.table("events").with_schema("public");
 let stream = table
     .append_stream()
-    .batch_bytes(4 * 1024 * 1024)
+    .target_batch_bytes(4 * 1024 * 1024)
+    .max_batch_rows(10_000)
     .flush_interval(Duration::from_secs(1))
-    .max_in_flight_requests(4)
-    .max_pending_bytes(64 * 1024 * 1024)
+    .max_concurrent_batches(4)
+    .max_buffered_bytes(64 * 1024 * 1024)
     .build()?;
 
 let admitted = stream
@@ -206,7 +236,7 @@ deciding how to reconcile the covered rows.
 
 The default `AppendFailurePolicy::Stop` is strict: the first failed batch stops
 admission, and a successful barrier confirms that its accepted prefix committed.
-Use `max_in_flight_requests(1)` if request submission order matters; concurrent
+Use `max_concurrent_batches(1)` if request submission order matters; concurrent
 batches have no defined commit order.
 
 ### Best-effort telemetry and logs
@@ -293,8 +323,8 @@ available for reconciliation.
 let table = client.table("events").with_schema("public");
 println!("identifier = {}", table.identifier());
 
-let schema = table.table_schema().await?;
-println!("fields = {}", schema.fields().len());
+let description = table.describe().await?;
+println!("columns = {}", description.columns.len());
 # Ok(())
 # }
 ```

--- a/rust/README.md
+++ b/rust/README.md
@@ -69,9 +69,10 @@ form for intentionally duplicated columns. `first()` converts only the first
 row for point lookups and aggregates.
 
 For lifecycle control, call `client.statement(scopeql).submit()` and retain the
-returned handle. `refresh()` fetches one status snapshot, `wait()` polls to a
-terminal result, and `cancel()` requests cancellation. The statement ID is
-available immediately after submission.
+returned handle. `last_status()` reads the latest cached snapshot without a
+network request, `status().await` fetches one current status, `wait()` polls to
+a terminal result, and `cancel()` requests cancellation. The statement ID and
+initial status snapshot are available immediately after submission.
 
 ## Browse the catalog
 

--- a/rust/RELEASE.md
+++ b/rust/RELEASE.md
@@ -46,21 +46,21 @@ and verify the exact package that Cargo will upload:
 
 ```sh
 cd rust
-cargo +1.85.0 generate-lockfile
+cargo +1.91.0 generate-lockfile
 manifest_version="$(cargo pkgid | sed -E 's/.*@([^@]+)$/\1/')"
 test "$manifest_version" = "$scopedb_rust_version"
 cargo +nightly fmt --all --check
 cargo +nightly clippy --locked --tests --all-targets --all-features -- -D warnings
-cargo +1.85.0 test --locked --all-targets --all-features
-RUSTDOCFLAGS="-D warnings" cargo +1.85.0 doc --locked --no-deps --all-features
-cargo +1.85.0 publish --dry-run --locked
-cargo +1.85.0 package --list --locked
+cargo +1.91.0 test --locked --all-targets --all-features
+RUSTDOCFLAGS="-D warnings" cargo +1.91.0 doc --locked --no-deps --all-features
+cargo +1.91.0 publish --dry-run --locked
+cargo +1.91.0 package --list --locked
 ```
 
 Publish once from that same clean commit:
 
 ```sh
-cargo +1.85.0 publish --locked
+cargo +1.91.0 publish --locked
 ```
 
 Wait until the published version is visible before tagging:

--- a/rust/examples/README.md
+++ b/rust/examples/README.md
@@ -2,9 +2,9 @@
 
 Start with a quickstart, then choose a write pattern whose delivery tradeoffs
 match the workload. Every example uses only the public `scopedb-client` API.
-The shared client helper uses the SDK's compatible HTTP client re-export at
-`scopedb_client::reqwest`, so copied examples do not need a direct reqwest
-dependency.
+The shared client helper uses `Client::builder(...).api_key(...)`, so copied
+examples do not need a direct reqwest dependency. API keys belong only in a
+trusted process; never return one to an untrusted client.
 
 These examples focus on SDK integration and assume valid ScopeQL. For language
 syntax, use the canonical [Quickstart](https://docs.scopedb.io/guides/quickstart),
@@ -20,9 +20,9 @@ data.
 
 | Example | Shows | Run |
 | --- | --- | --- |
-| [`statement.rs`](statement.rs) | Statement execution and typed result values | `cargo run --example statement` |
-| [`catalog.rs`](catalog.rs) | REST catalog pagination and full table metadata | `cargo run --example catalog` |
-| [`table.rs`](table.rs) | Quoted table identifiers and the table schema helper | `cargo run --example table` |
+| [`statement.rs`](statement.rs) | Query shorthand and object result rows | `cargo run --example statement` |
+| [`catalog.rs`](catalog.rs) | Automatic REST catalog pagination and full resources | `cargo run --example catalog` |
+| [`table.rs`](table.rs) | Quoted table identifiers and full table descriptions | `cargo run --example table` |
 
 ## Before running a write example
 
@@ -109,7 +109,7 @@ wait for a later probe.
   keep the future alive to receive the interval report and use `stats()` for
   post-cancellation diagnostics.
 - Concurrent batches do not have a defined commit order. Use
-  `max_in_flight_requests(1)` when requests must be submitted serially.
+  `max_concurrent_batches(1)` when requests must be submitted serially.
 - An in-memory stream is not a durable queue. Audit or billing writes need an
   application-owned outbox and a reconciliation path for unknown outcomes.
 

--- a/rust/examples/bulk_append.rs
+++ b/rust/examples/bulk_append.rs
@@ -28,10 +28,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // defined commit order.
     let stream = table
         .append_stream()
-        .batch_bytes(32 * 1024)
+        .target_batch_bytes(32 * 1024)
+        .max_batch_rows(10_000)
         .flush_interval(Duration::from_secs(1))
-        .max_pending_bytes(1024 * 1024)
-        .max_in_flight_requests(4)
+        .max_buffered_bytes(1024 * 1024)
+        .max_concurrent_batches(4)
         .attempt_timeout(Duration::from_secs(30))
         .build()?;
 

--- a/rust/examples/catalog.rs
+++ b/rust/examples/catalog.rs
@@ -22,44 +22,31 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let database = common::database();
     let schema = common::schema();
 
-    let mut page_token = None;
-    loop {
-        let page = client
-            .list_databases(CatalogListOptions {
-                page_size: Some(100),
-                page_token,
-            })
-            .await?;
-        for item in page.items {
-            println!(
-                "database {}: {}",
-                item.name,
-                item.comment.unwrap_or_default()
-            );
-        }
-        page_token = page.next_page_token;
-        if page_token.is_none() {
-            break;
-        }
+    let mut databases = client.iterate_databases(CatalogListOptions {
+        page_size: Some(100),
+        page_token: None,
+    });
+    while let Some(item) = databases.next().await? {
+        println!(
+            "database {}: {}",
+            item.name,
+            item.comment.unwrap_or_default()
+        );
     }
 
     let database_resource = client.fetch_database(&database).await?;
     println!("selected database: {database_resource:?}");
 
-    let schemas = client
-        .list_schemas(&database, CatalogListOptions::default())
-        .await?;
-    for item in schemas.items {
+    let mut schemas = client.iterate_schemas(&database, CatalogListOptions::default());
+    while let Some(item) = schemas.next().await? {
         println!("schema {}.{}", item.database, item.name);
     }
 
     let schema_resource = client.fetch_schema(&database, &schema).await?;
     println!("selected schema: {schema_resource:?}");
 
-    let tables = client
-        .list_tables(&database, &schema, CatalogListOptions::default())
-        .await?;
-    if let Some(first) = tables.items.first() {
+    let mut tables = client.iterate_tables(&database, &schema, CatalogListOptions::default());
+    if let Some(first) = tables.next().await? {
         println!("first table summary: {first:?}");
         let resource = client.fetch_table(&database, &schema, &first.name).await?;
         println!("first table resource: {resource:?}");

--- a/rust/examples/common/mod.rs
+++ b/rust/examples/common/mod.rs
@@ -18,10 +18,6 @@ use std::io;
 
 use scopedb_client::Client;
 use scopedb_client::Table;
-use scopedb_client::reqwest;
-use scopedb_client::reqwest::header::AUTHORIZATION;
-use scopedb_client::reqwest::header::HeaderMap;
-use scopedb_client::reqwest::header::HeaderValue;
 
 pub fn endpoint() -> String {
     std::env::var("SCOPEDB_ENDPOINT").unwrap_or_else(|_| "http://127.0.0.1:6543".to_string())
@@ -36,8 +32,7 @@ pub fn schema() -> String {
 }
 
 pub fn client() -> Result<Client, Box<dyn std::error::Error>> {
-    let mut headers = HeaderMap::new();
-    let token = std::env::var("SCOPEDB_API_KEY")
+    let api_key = std::env::var("SCOPEDB_API_KEY")
         .ok()
         .filter(|value| !value.is_empty())
         .or_else(|| {
@@ -45,16 +40,11 @@ pub fn client() -> Result<Client, Box<dyn std::error::Error>> {
                 .ok()
                 .filter(|value| !value.is_empty())
         });
-    if let Some(token) = token {
-        let mut authorization = HeaderValue::from_str(&format!("Bearer {token}"))?;
-        authorization.set_sensitive(true);
-        headers.insert(AUTHORIZATION, authorization);
+    let mut builder = Client::builder(endpoint());
+    if let Some(api_key) = api_key {
+        builder = builder.api_key(api_key);
     }
-
-    let http_client = reqwest::Client::builder()
-        .default_headers(headers)
-        .build()?;
-    Ok(Client::new(endpoint(), http_client)?)
+    Ok(builder.build()?)
 }
 
 pub fn write_table(client: &Client) -> Result<Table, io::Error> {

--- a/rust/examples/statement.rs
+++ b/rust/examples/statement.rs
@@ -26,7 +26,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // durable statement ID before waiting for the result.
     let mut handle = client.statement("SELECT 2 AS value").submit().await?;
     let statement_id = handle.statement_id();
-    let status = handle.refresh().await?;
+    println!(
+        "statement {statement_id} submitted: {:?}",
+        handle.last_status()
+    );
+    let status = handle.status().await?;
     println!("statement {statement_id}: {status:?}");
     let result = handle.wait().await?;
     println!("handle rows: {:?}", result.into_objects()?);

--- a/rust/examples/statement.rs
+++ b/rust/examples/statement.rs
@@ -18,9 +18,17 @@ mod common;
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let client = common::client()?;
 
-    let result = client.statement("SELECT 1".to_string()).execute().await?;
-
-    let rows = result.into_values()?;
+    let result = client.query("SELECT 1 AS ready").await?;
+    let rows = result.into_objects()?;
     println!("rows: {rows:?}");
+
+    // Keep the handle when an application needs progress, cancellation, or a
+    // durable statement ID before waiting for the result.
+    let mut handle = client.statement("SELECT 2 AS value").submit().await?;
+    let statement_id = handle.statement_id();
+    let status = handle.refresh().await?;
+    println!("statement {statement_id}: {status:?}");
+    let result = handle.wait().await?;
+    println!("handle rows: {:?}", result.into_objects()?);
     Ok(())
 }

--- a/rust/examples/table.rs
+++ b/rust/examples/table.rs
@@ -25,9 +25,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     println!("identifier: {}", table.identifier());
 
-    let schema = table.table_schema().await?;
-    for field in schema.fields() {
-        println!("{}: {:?}", field.name(), field.data_type());
+    let description = table.describe().await?;
+    for column in description.columns {
+        println!("{}: {:?}", column.name, column.data_type);
     }
 
     Ok(())

--- a/rust/examples/telemetry.rs
+++ b/rust/examples/telemetry.rs
@@ -48,10 +48,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let telemetry = table
         .append_stream()
         .failure_policy(AppendFailurePolicy::Continue)
-        .batch_bytes(1024 * 1024)
+        .target_batch_bytes(1024 * 1024)
+        .max_batch_rows(10_000)
         .flush_interval(Duration::from_secs(1))
-        .max_pending_bytes(32 * 1024 * 1024)
-        .max_in_flight_requests(2)
+        .max_buffered_bytes(32 * 1024 * 1024)
+        .max_concurrent_batches(2)
         .attempt_timeout(Duration::from_secs(10))
         .on_batch_failure(|event| {
             // A synchronous observer; use a separate diagnostics sink.

--- a/rust/rust-toolchain.toml
+++ b/rust/rust-toolchain.toml
@@ -13,5 +13,5 @@
 # limitations under the License.
 
 [toolchain]
-channel = "1.85.0"
+channel = "1.91.0"
 components = ["cargo", "rustfmt", "clippy", "rust-analyzer"]

--- a/rust/src/append_stream.rs
+++ b/rust/src/append_stream.rs
@@ -43,6 +43,7 @@ use crate::ErrorKind;
 const MAX_APPEND_BODY_BYTES: usize = 16 * 1024 * 1024;
 const MAX_APPEND_ROWS: usize = 200_000;
 const DEFAULT_BATCH_BYTES: usize = MAX_APPEND_BODY_BYTES;
+const DEFAULT_MAX_BATCH_ROWS: usize = MAX_APPEND_ROWS;
 const DEFAULT_FLUSH_INTERVAL: Duration = Duration::from_secs(1);
 const DEFAULT_CHANNEL_CAPACITY: usize = 1024;
 const DEFAULT_MAX_IN_FLIGHT_REQUESTS: usize = 4;
@@ -266,6 +267,7 @@ pub struct AppendStreamBuilder {
     schema: String,
     table: String,
     batch_bytes: usize,
+    max_batch_rows: usize,
     flush_interval: Duration,
     channel_capacity: usize,
     max_pending_bytes: usize,
@@ -285,6 +287,7 @@ impl AppendStreamBuilder {
             schema,
             table,
             batch_bytes: DEFAULT_BATCH_BYTES,
+            max_batch_rows: DEFAULT_MAX_BATCH_ROWS,
             flush_interval: DEFAULT_FLUSH_INTERVAL,
             channel_capacity: DEFAULT_CHANNEL_CAPACITY,
             max_pending_bytes: DEFAULT_MAX_PENDING_BYTES,
@@ -307,8 +310,21 @@ impl AppendStreamBuilder {
     }
 
     /// Sets the target NDJSON payload size. One row may exceed this target up to 16 MiB.
+    #[deprecated(note = "use target_batch_bytes")]
     pub fn batch_bytes(mut self, batch_bytes: usize) -> Self {
         self.batch_bytes = batch_bytes;
+        self
+    }
+
+    /// Sets the target NDJSON payload size. One row may exceed this target up to 16 MiB.
+    pub fn target_batch_bytes(mut self, target_batch_bytes: usize) -> Self {
+        self.batch_bytes = target_batch_bytes;
+        self
+    }
+
+    /// Sets the maximum rows in one HTTP batch, up to the 200,000-row protocol limit.
+    pub fn max_batch_rows(mut self, max_batch_rows: usize) -> Self {
+        self.max_batch_rows = max_batch_rows;
         self
     }
 
@@ -323,14 +339,29 @@ impl AppendStreamBuilder {
         self
     }
 
+    /// Backward-compatible alias for [`AppendStreamBuilder::max_buffered_bytes`].
+    #[deprecated(note = "use max_buffered_bytes")]
     pub fn max_pending_bytes(mut self, max_pending_bytes: usize) -> Self {
         self.max_pending_bytes = max_pending_bytes;
         self
     }
 
+    /// Sets the maximum bytes admitted locally but not yet settled remotely.
+    pub fn max_buffered_bytes(mut self, max_buffered_bytes: usize) -> Self {
+        self.max_pending_bytes = max_buffered_bytes;
+        self
+    }
+
     /// Sets the maximum number of append HTTP requests running concurrently.
+    #[deprecated(note = "use max_concurrent_batches")]
     pub fn max_in_flight_requests(mut self, max_in_flight_requests: usize) -> Self {
         self.max_in_flight_requests = max_in_flight_requests;
+        self
+    }
+
+    /// Sets the maximum number of append batches sent concurrently.
+    pub fn max_concurrent_batches(mut self, max_concurrent_batches: usize) -> Self {
+        self.max_in_flight_requests = max_concurrent_batches;
         self
     }
 
@@ -390,6 +421,7 @@ impl AppendStreamBuilder {
             schema: self.schema,
             table: self.table,
             batch_bytes: self.batch_bytes,
+            max_batch_rows: self.max_batch_rows,
             flush_interval: self.flush_interval,
             channel_capacity: self.channel_capacity,
             max_pending_bytes: self.max_pending_bytes,
@@ -404,10 +436,16 @@ impl AppendStreamBuilder {
 }
 
 fn validate_builder(builder: &AppendStreamBuilder) -> Result<(), Error> {
-    validate_positive("batch_bytes", builder.batch_bytes)?;
+    validate_positive("target_batch_bytes", builder.batch_bytes)?;
     if builder.batch_bytes > MAX_APPEND_BODY_BYTES {
         return Err(config_error(format!(
-            "batch_bytes must not exceed {MAX_APPEND_BODY_BYTES}"
+            "target_batch_bytes must not exceed {MAX_APPEND_BODY_BYTES}"
+        )));
+    }
+    validate_positive("max_batch_rows", builder.max_batch_rows)?;
+    if builder.max_batch_rows > MAX_APPEND_ROWS {
+        return Err(config_error(format!(
+            "max_batch_rows must not exceed {MAX_APPEND_ROWS}"
         )));
     }
     if builder.flush_interval.is_zero() {
@@ -415,14 +453,14 @@ fn validate_builder(builder: &AppendStreamBuilder) -> Result<(), Error> {
     }
     validate_deadline("flush_interval", builder.flush_interval)?;
     validate_positive("channel_capacity", builder.channel_capacity)?;
-    validate_positive("max_pending_bytes", builder.max_pending_bytes)?;
+    validate_positive("max_buffered_bytes", builder.max_pending_bytes)?;
     if builder.max_pending_bytes > u32::MAX as usize {
         return Err(config_error(format!(
-            "max_pending_bytes must not exceed {}",
+            "max_buffered_bytes must not exceed {}",
             u32::MAX
         )));
     }
-    validate_positive("max_in_flight_requests", builder.max_in_flight_requests)?;
+    validate_positive("max_concurrent_batches", builder.max_in_flight_requests)?;
     if builder
         .attempt_timeout
         .is_some_and(|attempt_timeout| attempt_timeout.is_zero())
@@ -473,6 +511,7 @@ struct AppendStreamConfig {
     schema: String,
     table: String,
     batch_bytes: usize,
+    max_batch_rows: usize,
     flush_interval: Duration,
     channel_capacity: usize,
     max_pending_bytes: usize,
@@ -1095,6 +1134,9 @@ struct StreamErrorSnapshot {
     message: String,
     status: SnapshotStatus,
     append_details: Option<AppendErrorDetails>,
+    http_status: Option<reqwest::StatusCode>,
+    request_id: Option<String>,
+    retry_after: Option<Duration>,
 }
 
 impl StreamErrorSnapshot {
@@ -1111,6 +1153,9 @@ impl StreamErrorSnapshot {
             message: error.message().to_string(),
             status,
             append_details: error.append_details().cloned(),
+            http_status: error.http_status(),
+            request_id: error.request_id().map(str::to_string),
+            retry_after: error.retry_after(),
         }
     }
 
@@ -1118,6 +1163,15 @@ impl StreamErrorSnapshot {
         let mut error = Error::new(self.kind, self.message.clone());
         if let Some(details) = self.append_details.clone() {
             error = error.set_append_details(details);
+        }
+        if let Some(status) = self.http_status {
+            error = error.set_http_status(status);
+        }
+        if let Some(request_id) = self.request_id.clone() {
+            error = error.set_request_id(request_id);
+        }
+        if let Some(retry_after) = self.retry_after {
+            error = error.set_retry_after(retry_after);
         }
         match self.status {
             SnapshotStatus::Permanent => error.set_permanent(),
@@ -1300,7 +1354,9 @@ impl AppendWorker {
         }
         self.current_bytes = self.current_bytes.saturating_add(record.payload.len());
         self.rows.push(record);
-        if self.current_bytes >= self.config.batch_bytes || self.rows.len() >= MAX_APPEND_ROWS {
+        if self.current_bytes >= self.config.batch_bytes
+            || self.rows.len() >= self.config.max_batch_rows
+        {
             self.dispatch_buffered().await;
         }
     }
@@ -1708,8 +1764,9 @@ async fn append_batch(
         match result {
             Ok(result) => return (Ok(result), retries),
             Err(error) if append_retryable(&error) && retries < request.retry.max_retries => {
-                if !backoff.is_zero() {
-                    tokio::time::sleep(backoff).await;
+                let retry_delay = retry_delay(backoff, &error, request.retry.max_backoff);
+                if !retry_delay.is_zero() {
+                    tokio::time::sleep(retry_delay).await;
                 }
                 retries += 1;
                 backoff = next_backoff(backoff, request.retry.max_backoff);
@@ -1755,6 +1812,12 @@ fn next_backoff(current: Duration, max_backoff: Duration) -> Duration {
     current
         .checked_mul(2)
         .unwrap_or(max_backoff)
+        .min(max_backoff)
+}
+
+fn retry_delay(backoff: Duration, error: &Error, max_backoff: Duration) -> Duration {
+    backoff
+        .max(error.retry_after().unwrap_or(Duration::ZERO))
         .min(max_backoff)
 }
 
@@ -2148,6 +2211,7 @@ mod tests {
             schema: "public".to_string(),
             table: "events".to_string(),
             batch_bytes: 1024,
+            max_batch_rows: 100,
             flush_interval: Duration::from_secs(1),
             channel_capacity: 1,
             max_pending_bytes: 1024,
@@ -2195,6 +2259,55 @@ mod tests {
         );
     }
 
+    #[test]
+    fn retry_after_is_honored_and_capped() {
+        let error = Error::new(ErrorKind::AppendRowsFailed, "busy")
+            .set_retry_after(Duration::from_secs(30));
+        assert_eq!(
+            retry_delay(Duration::from_millis(100), &error, Duration::from_secs(5)),
+            Duration::from_secs(5)
+        );
+
+        let error = Error::new(ErrorKind::AppendRowsFailed, "busy")
+            .set_retry_after(Duration::from_millis(200));
+        assert_eq!(
+            retry_delay(Duration::from_secs(1), &error, Duration::from_secs(5)),
+            Duration::from_secs(1)
+        );
+    }
+
+    #[test]
+    fn max_batch_rows_cannot_exceed_protocol_limit() {
+        let result = Client::new("https://example.com", reqwest::Client::new())
+            .unwrap()
+            .table("events")
+            .append_stream()
+            .max_batch_rows(MAX_APPEND_ROWS + 1)
+            .build();
+        let error = match result {
+            Ok(_) => panic!("invalid max_batch_rows was accepted"),
+            Err(error) => error,
+        };
+        assert_eq!(error.kind(), ErrorKind::ConfigInvalid);
+    }
+
+    #[test]
+    fn error_snapshot_preserves_http_metadata() {
+        let error = Error::new(ErrorKind::AppendRowsFailed, "busy")
+            .set_http_status(reqwest::StatusCode::SERVICE_UNAVAILABLE)
+            .set_request_id("request-123".to_string())
+            .set_retry_after(Duration::from_secs(2))
+            .set_temporary();
+        let restored = StreamErrorSnapshot::from_error(&error).to_error();
+        assert_eq!(
+            restored.http_status(),
+            Some(reqwest::StatusCode::SERVICE_UNAVAILABLE)
+        );
+        assert_eq!(restored.request_id(), Some("request-123"));
+        assert_eq!(restored.retry_after(), Some(Duration::from_secs(2)));
+        assert!(restored.is_temporary());
+    }
+
     #[tokio::test]
     async fn batches_ndjson_and_runs_requests_concurrently() {
         let server = MockServer::start(|_, request| {
@@ -2206,8 +2319,8 @@ mod tests {
             .with_database("analytics 2026")
             .with_schema("public")
             .append_stream()
-            .batch_bytes(1)
-            .max_in_flight_requests(3)
+            .target_batch_bytes(1)
+            .max_concurrent_batches(3)
             .build()
             .unwrap();
 
@@ -2240,6 +2353,56 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn semantic_builder_names_split_batches_by_row_count() {
+        let server = MockServer::start(|_, request| MockResponse::committed(request));
+        let stream = server
+            .client()
+            .table("events")
+            .append_stream()
+            .target_batch_bytes(1024 * 1024)
+            .max_batch_rows(2)
+            .max_buffered_bytes(1024 * 1024)
+            .max_concurrent_batches(1)
+            .build()
+            .unwrap();
+
+        stream
+            .send_all((0..5).map(|id| serde_json::json!({"id": id})))
+            .await
+            .unwrap();
+        let report = stream.shutdown().await.unwrap();
+
+        assert_eq!(report.committed_rows, 5);
+        let row_counts = server
+            .requests()
+            .iter()
+            .map(|request| request.body.lines().count())
+            .collect::<Vec<_>>();
+        assert_eq!(row_counts, vec![2, 2, 1]);
+    }
+
+    #[tokio::test]
+    async fn client_builder_attaches_api_key_to_requests() {
+        let server = MockServer::start(|_, request| MockResponse::committed(request));
+        let http_client = reqwest::Client::builder().no_proxy().build().unwrap();
+        let client = Client::builder(&server.endpoint)
+            .api_key("secret-api-key")
+            .http_client(http_client)
+            .build()
+            .unwrap();
+
+        client.table("events").append(r#"{"id":1}"#).await.unwrap();
+
+        assert_eq!(
+            server.requests()[0]
+                .headers
+                .get("authorization")
+                .map(String::as_str),
+            Some("Bearer secret-api-key")
+        );
+    }
+
+    #[tokio::test]
     async fn continue_mode_retries_only_temporary_rejections() {
         let server = MockServer::start(|index, request| match index {
             0 => MockResponse::json(503, r#"{"message":"busy","append_state":"rejected"}"#),
@@ -2254,8 +2417,8 @@ mod tests {
             .append_stream()
             .failure_policy(AppendFailurePolicy::Continue)
             .circuit_breaker(None)
-            .batch_bytes(1)
-            .max_in_flight_requests(1)
+            .target_batch_bytes(1)
+            .max_concurrent_batches(1)
             .max_retries(4)
             .initial_backoff(Duration::ZERO)
             .max_backoff(Duration::ZERO)
@@ -2295,7 +2458,7 @@ mod tests {
             .append_stream()
             .failure_policy(AppendFailurePolicy::Continue)
             .circuit_breaker(None)
-            .batch_bytes(1)
+            .target_batch_bytes(1)
             .max_retries(8)
             .attempt_timeout(Duration::from_millis(10))
             .build()
@@ -2320,8 +2483,8 @@ mod tests {
             .client()
             .table("events")
             .append_stream()
-            .batch_bytes(1)
-            .max_in_flight_requests(1)
+            .target_batch_bytes(1)
+            .max_concurrent_batches(1)
             .build()
             .unwrap();
         stream
@@ -2359,8 +2522,8 @@ mod tests {
             .client()
             .table("events")
             .append_stream()
-            .batch_bytes(1)
-            .max_in_flight_requests(2)
+            .target_batch_bytes(1)
+            .max_concurrent_batches(2)
             .build()
             .unwrap();
         stream
@@ -2436,7 +2599,7 @@ mod tests {
             .table("events")
             .append_stream()
             .failure_policy(AppendFailurePolicy::Continue)
-            .max_pending_bytes(1)
+            .max_buffered_bytes(1)
             .build()
             .unwrap();
 

--- a/rust/src/catalog.rs
+++ b/rust/src/catalog.rs
@@ -100,16 +100,16 @@ where
             })
             .await?;
 
-            if let Some(token) = page.next_page_token.as_ref() {
-                if !self.seen_tokens.insert(token.clone()) {
-                    self.exhausted = true;
-                    self.items = page.items.into();
-                    self.terminal_error = Some(Error::new(
-                        ErrorKind::Unexpected,
-                        "catalog pagination returned a repeated page token",
-                    ));
-                    continue;
-                }
+            if let Some(token) = page.next_page_token.as_ref()
+                && !self.seen_tokens.insert(token.clone())
+            {
+                self.exhausted = true;
+                self.items = page.items.into();
+                self.terminal_error = Some(Error::new(
+                    ErrorKind::Unexpected,
+                    "catalog pagination returned a repeated page token",
+                ));
+                continue;
             }
             self.next_page_token = page.next_page_token;
             self.exhausted = self.next_page_token.is_none();

--- a/rust/src/catalog.rs
+++ b/rust/src/catalog.rs
@@ -1,0 +1,169 @@
+// Copyright 2024 ScopeDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashSet;
+use std::collections::VecDeque;
+use std::fmt;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use crate::CatalogListOptions;
+use crate::CatalogPage;
+use crate::Error;
+use crate::ErrorKind;
+
+type PageFuture<T> = Pin<Box<dyn Future<Output = Result<CatalogPage<T>, Error>> + Send>>;
+type PageFetcher<T> = Arc<dyn Fn(CatalogListOptions) -> PageFuture<T> + Send + Sync>;
+
+/// Lazily iterates catalog resources across every page.
+///
+/// Call [`CatalogIterator::next`] until it returns `None`. A page is requested
+/// only when the local item buffer is empty, so stopping iteration does not
+/// fetch unused pages.
+#[must_use = "catalog iterators are lazy; call next().await to fetch resources"]
+pub struct CatalogIterator<T> {
+    fetch_page: PageFetcher<T>,
+    page_size: Option<usize>,
+    next_page_token: Option<String>,
+    seen_tokens: HashSet<String>,
+    items: VecDeque<T>,
+    exhausted: bool,
+    terminal_error: Option<Error>,
+}
+
+impl<T> fmt::Debug for CatalogIterator<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CatalogIterator")
+            .field("page_size", &self.page_size)
+            .field("next_page_token", &self.next_page_token)
+            .field("buffered_items", &self.items.len())
+            .field("exhausted", &self.exhausted)
+            .field("has_terminal_error", &self.terminal_error.is_some())
+            .finish_non_exhaustive()
+    }
+}
+
+impl<T> CatalogIterator<T>
+where
+    T: Send + 'static,
+{
+    pub(crate) fn new<F, Fut>(options: CatalogListOptions, fetch_page: F) -> Self
+    where
+        F: Fn(CatalogListOptions) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = Result<CatalogPage<T>, Error>> + Send + 'static,
+    {
+        let next_page_token = options.page_token;
+        let seen_tokens = next_page_token.iter().cloned().collect();
+        let fetch_page = Arc::new(move |options| {
+            let future = fetch_page(options);
+            Box::pin(future) as PageFuture<T>
+        });
+        Self {
+            fetch_page,
+            page_size: options.page_size,
+            next_page_token,
+            seen_tokens,
+            items: VecDeque::new(),
+            exhausted: false,
+            terminal_error: None,
+        }
+    }
+
+    /// Returns the next resource, fetching another page when necessary.
+    pub async fn next(&mut self) -> Result<Option<T>, Error> {
+        loop {
+            if let Some(item) = self.items.pop_front() {
+                return Ok(Some(item));
+            }
+            if let Some(error) = self.terminal_error.take() {
+                return Err(error);
+            }
+            if self.exhausted {
+                return Ok(None);
+            }
+
+            let page = (self.fetch_page)(CatalogListOptions {
+                page_size: self.page_size,
+                page_token: self.next_page_token.clone(),
+            })
+            .await?;
+
+            if let Some(token) = page.next_page_token.as_ref() {
+                if !self.seen_tokens.insert(token.clone()) {
+                    self.exhausted = true;
+                    self.items = page.items.into();
+                    self.terminal_error = Some(Error::new(
+                        ErrorKind::Unexpected,
+                        "catalog pagination returned a repeated page token",
+                    ));
+                    continue;
+                }
+            }
+            self.next_page_token = page.next_page_token;
+            self.exhausted = self.next_page_token.is_none();
+            self.items = page.items.into();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn iterates_pages_and_rejects_repeated_tokens() {
+        let calls = Arc::new(Mutex::new(Vec::new()));
+        let mut catalog = CatalogIterator::new(CatalogListOptions::default(), {
+            let calls = calls.clone();
+            move |options| {
+                let calls = calls.clone();
+                async move {
+                    calls.lock().unwrap().push(options.page_token.clone());
+                    match options.page_token.as_deref() {
+                        None => Ok(CatalogPage {
+                            items: vec![1, 2],
+                            next_page_token: Some("next".to_string()),
+                        }),
+                        Some("next") => Ok(CatalogPage {
+                            items: vec![3],
+                            next_page_token: None,
+                        }),
+                        _ => unreachable!(),
+                    }
+                }
+            }
+        });
+
+        assert_eq!(catalog.next().await.unwrap(), Some(1));
+        assert_eq!(catalog.next().await.unwrap(), Some(2));
+        assert_eq!(catalog.next().await.unwrap(), Some(3));
+        assert_eq!(catalog.next().await.unwrap(), None);
+        assert_eq!(*calls.lock().unwrap(), vec![None, Some("next".to_string())]);
+
+        let mut repeated = CatalogIterator::new(CatalogListOptions::default(), |_| async {
+            Ok(CatalogPage {
+                items: vec![7_u8],
+                next_page_token: Some("same".to_string()),
+            })
+        });
+        assert_eq!(repeated.next().await.unwrap(), Some(7));
+        assert_eq!(repeated.next().await.unwrap(), Some(7));
+        let error = repeated.next().await.unwrap_err();
+        assert_eq!(error.kind(), ErrorKind::Unexpected);
+        assert_eq!(repeated.next().await.unwrap(), None);
+    }
+}

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -14,14 +14,19 @@
 
 use fastrace_reqwest::traceparent_headers;
 use reqwest::IntoUrl;
+use reqwest::Method;
 use reqwest::StatusCode;
 use reqwest::Url;
+use reqwest::header::AUTHORIZATION;
+use reqwest::header::HeaderValue;
 use serde::de::DeserializeOwned;
 use uuid::Uuid;
 
+use crate::CatalogIterator;
 use crate::Error;
 use crate::ErrorKind;
 use crate::IngestStreamBuilder;
+use crate::ResultSet;
 use crate::Statement;
 use crate::Table;
 use crate::protocol::AppendErrorDetails;
@@ -44,16 +49,88 @@ use crate::protocol::StatementRequestParams;
 use crate::protocol::StatementStatus;
 use crate::protocol::TableResource;
 use crate::protocol::TableResourceSummary;
-use crate::protocol::http_error_message;
+use crate::protocol::apply_response_metadata;
 use crate::statement::StatementHandle;
 
 #[derive(Debug, Clone)]
 pub struct Client {
     endpoint: Url,
     client: reqwest::Client,
+    authorization: Option<HeaderValue>,
+}
+
+/// Builds a ScopeDB client with an optional API key and custom HTTP client.
+///
+/// The API key is attached by the ScopeDB client itself, so callers can still
+/// provide a preconfigured reqwest client for TLS, proxy, timeout, and pooling
+/// settings.
+pub struct ClientBuilder {
+    endpoint: String,
+    client: Option<reqwest::Client>,
+    api_key: Option<String>,
+}
+
+impl std::fmt::Debug for ClientBuilder {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ClientBuilder")
+            .field("endpoint", &self.endpoint)
+            .field("client", &self.client)
+            .field("has_api_key", &self.api_key.is_some())
+            .finish()
+    }
+}
+
+impl ClientBuilder {
+    /// Sets the ScopeDB API key sent as a sensitive Bearer credential.
+    ///
+    /// This per-request value takes precedence over an `Authorization` default
+    /// configured on the underlying HTTP client.
+    pub fn api_key(mut self, api_key: impl Into<String>) -> Self {
+        self.api_key = Some(api_key.into());
+        self
+    }
+
+    /// Uses a preconfigured compatible HTTP client.
+    pub fn http_client(mut self, client: reqwest::Client) -> Self {
+        self.client = Some(client);
+        self
+    }
+
+    /// Validates the endpoint and authentication settings and builds the client.
+    pub fn build(self) -> Result<Client, Error> {
+        let mut client = Client::new(self.endpoint, self.client.unwrap_or_default())?;
+        if let Some(api_key) = self.api_key {
+            if api_key.is_empty() {
+                return Err(Error::new(
+                    ErrorKind::ConfigInvalid,
+                    "api_key must not be empty",
+                ));
+            }
+            let mut authorization =
+                HeaderValue::from_str(&format!("Bearer {api_key}")).map_err(|err| {
+                    Error::new(
+                        ErrorKind::ConfigInvalid,
+                        "api_key is not a valid HTTP credential",
+                    )
+                    .set_source(err)
+                })?;
+            authorization.set_sensitive(true);
+            client.authorization = Some(authorization);
+        }
+        Ok(client)
+    }
 }
 
 impl Client {
+    /// Starts a client builder for the common API-key authentication path.
+    pub fn builder(endpoint: impl ToString) -> ClientBuilder {
+        ClientBuilder {
+            endpoint: endpoint.to_string(),
+            client: None,
+            api_key: None,
+        }
+    }
+
     /// Creates a ScopeDB client from an endpoint and a compatible HTTP client.
     ///
     /// Use the HTTP types re-exported from [`crate::reqwest`] to avoid a
@@ -65,7 +142,11 @@ impl Client {
                     let path = format!("{}/", endpoint.path());
                     endpoint.set_path(&path);
                 }
-                Ok(Self { endpoint, client })
+                Ok(Self {
+                    endpoint,
+                    client,
+                    authorization: None,
+                })
             }
             Err(err) => Err(Error::new(
                 ErrorKind::ConfigInvalid,
@@ -75,8 +156,8 @@ impl Client {
         }
     }
 
-    pub fn statement(&self, statement: String) -> Statement {
-        Statement::new(self.clone(), statement)
+    pub fn statement(&self, statement: impl Into<String>) -> Statement {
+        Statement::new(self.clone(), statement.into())
     }
 
     pub fn statement_handle(&self, statement_id: Uuid) -> StatementHandle {
@@ -91,12 +172,29 @@ impl Client {
         IngestStreamBuilder::new(self.clone(), statement.into())
     }
 
+    /// Executes a ScopeQL statement and waits for all result rows.
+    pub async fn query(&self, statement: impl Into<String>) -> Result<ResultSet, Error> {
+        self.statement(statement).execute().await
+    }
+
     pub async fn list_databases(
         &self,
         options: CatalogListOptions,
     ) -> Result<CatalogPage<DatabaseResource>, Error> {
         self.fetch_catalog(&["databases"], Some(&options), "failed to list databases")
             .await
+    }
+
+    /// Lazily iterates databases across every catalog page.
+    pub fn iterate_databases(
+        &self,
+        options: CatalogListOptions,
+    ) -> CatalogIterator<DatabaseResource> {
+        let client = self.clone();
+        CatalogIterator::new(options, move |options| {
+            let client = client.clone();
+            async move { client.list_databases(options).await }
+        })
     }
 
     pub async fn fetch_database(&self, database: &str) -> Result<DatabaseResource, Error> {
@@ -115,6 +213,21 @@ impl Client {
             "failed to list schemas",
         )
         .await
+    }
+
+    /// Lazily iterates schemas across every catalog page.
+    pub fn iterate_schemas(
+        &self,
+        database: impl Into<String>,
+        options: CatalogListOptions,
+    ) -> CatalogIterator<SchemaResource> {
+        let client = self.clone();
+        let database = database.into();
+        CatalogIterator::new(options, move |options| {
+            let client = client.clone();
+            let database = database.clone();
+            async move { client.list_schemas(&database, options).await }
+        })
     }
 
     pub async fn fetch_schema(
@@ -142,6 +255,24 @@ impl Client {
             "failed to list tables",
         )
         .await
+    }
+
+    /// Lazily iterates table summaries across every catalog page.
+    pub fn iterate_tables(
+        &self,
+        database: impl Into<String>,
+        schema: impl Into<String>,
+        options: CatalogListOptions,
+    ) -> CatalogIterator<TableResourceSummary> {
+        let client = self.clone();
+        let database = database.into();
+        let schema = schema.into();
+        CatalogIterator::new(options, move |options| {
+            let client = client.clone();
+            let database = database.clone();
+            let schema = schema.clone();
+            async move { client.list_tables(&database, &schema, options).await }
+        })
     }
 
     pub async fn fetch_table(
@@ -181,8 +312,7 @@ impl Client {
             "rows",
         ])?;
         let response = self
-            .client
-            .post(url)
+            .request(Method::POST, url)
             .headers(traceparent_headers())
             .header(reqwest::header::CONTENT_TYPE, "application/x-ndjson")
             .body(ndjson)
@@ -193,15 +323,24 @@ impl Client {
             })?;
 
         let status = response.status();
+        let headers = response.headers().clone();
         let payload = response.bytes().await.map_err(|err| {
-            append_unknown_error("failed to read table append response").set_source(err)
+            apply_response_metadata(
+                append_unknown_error("failed to read table append response").set_source(err),
+                status,
+                &headers,
+            )
         })?;
-        let result = decode_append_response(status, &payload)?;
+        let result = decode_append_response(status, &headers, &payload)?;
         if result.num_rows_inserted != expected_rows as i64 {
-            return Err(append_unknown_error(format!(
-                "table append response reported {} inserted rows for a {expected_rows}-row request",
-                result.num_rows_inserted
-            )));
+            return Err(apply_response_metadata(
+                append_unknown_error(format!(
+                    "table append response reported {} inserted rows for a {expected_rows}-row request",
+                    result.num_rows_inserted
+                )),
+                status,
+                &headers,
+            ));
         }
         Ok(result)
     }
@@ -216,10 +355,7 @@ impl Client {
             .await?
         {
             Response::Success(result) => Ok(result),
-            Response::Failed(err) => Err(map_failed_response(
-                err,
-                "failed to insert data".to_string(),
-            )),
+            Response::Failed(err) => Err(map_failed_response(err)),
         }
     }
 }
@@ -231,8 +367,13 @@ impl Client {
         options: Option<&CatalogListOptions>,
         operation: &'static str,
     ) -> Result<T, Error> {
+        if let Some(options) = options {
+            options.validate()?;
+        }
         let url = self.make_resource_url(segments)?;
-        let mut request = self.client.get(url).headers(traceparent_headers());
+        let mut request = self
+            .request(Method::GET, url)
+            .headers(traceparent_headers());
         if let Some(options) = options {
             request = request.query(options);
         }
@@ -243,7 +384,7 @@ impl Client {
         })?;
         match Response::from_http_response(response).await? {
             Response::Success(result) => Ok(result),
-            Response::Failed(err) => Err(map_failed_response(err, operation.to_string())),
+            Response::Failed(err) => Err(map_failed_response(err)),
         }
     }
 
@@ -254,18 +395,13 @@ impl Client {
     ) -> Result<Response<StatementStatus>, Error> {
         let url = self.make_url("v1/statements")?;
         let response = self
-            .client
-            .post(url)
+            .request(Method::POST, url)
             .headers(traceparent_headers())
             .json(&request)
             .send()
             .await
             .map_err(|err| {
-                Error::new(
-                    ErrorKind::Unexpected,
-                    format!("failed to submit statement: {request:?}"),
-                )
-                .set_source(err)
+                Error::new(ErrorKind::Unexpected, "failed to submit statement").set_source(err)
             })?;
         Response::from_http_response(response).await
     }
@@ -279,8 +415,7 @@ impl Client {
         let path = format!("v1/statements/{statement_id}");
         let url = self.make_url(&path)?;
         let response = self
-            .client
-            .get(url)
+            .request(Method::GET, url)
             .headers(traceparent_headers())
             .query(&params)
             .send()
@@ -291,6 +426,7 @@ impl Client {
                     format!("failed to fetch statement: {statement_id:?}"),
                 )
                 .set_source(err)
+                .set_temporary()
             })?;
         Response::from_http_response(response).await
     }
@@ -303,8 +439,7 @@ impl Client {
         let path = format!("v1/statements/{statement_id}/cancel");
         let url = self.make_url(&path)?;
         let response = self
-            .client
-            .post(url)
+            .request(Method::POST, url)
             .headers(traceparent_headers())
             .send()
             .await
@@ -314,6 +449,7 @@ impl Client {
                     format!("failed to cancel statement: {statement_id:?}"),
                 )
                 .set_source(err)
+                .set_temporary()
             })?;
         Response::from_http_response(response).await
     }
@@ -326,8 +462,7 @@ impl Client {
         let format = request.data.format();
         let url = self.make_url("v1/ingest")?;
         let response = self
-            .client
-            .post(url)
+            .request(Method::POST, url)
             .headers(traceparent_headers())
             .json(&request)
             .send()
@@ -362,22 +497,26 @@ impl Client {
         drop(path);
         Ok(url)
     }
-}
 
-fn map_failed_response(err: crate::protocol::ErrorStatus, message: String) -> Error {
-    let error = Error::new(ErrorKind::Unexpected, format!("{message}: {err}"));
-    match err.code() {
-        reqwest::StatusCode::REQUEST_TIMEOUT
-        | reqwest::StatusCode::TOO_MANY_REQUESTS
-        | reqwest::StatusCode::BAD_GATEWAY
-        | reqwest::StatusCode::SERVICE_UNAVAILABLE
-        | reqwest::StatusCode::GATEWAY_TIMEOUT => error.set_temporary(),
-        code if code.is_server_error() => error.set_temporary(),
-        _ => error.set_permanent(),
+    fn request(&self, method: Method, url: Url) -> reqwest::RequestBuilder {
+        let request = self.client.request(method, url);
+        if let Some(authorization) = &self.authorization {
+            request.header(AUTHORIZATION, authorization.clone())
+        } else {
+            request
+        }
     }
 }
 
-fn decode_append_response(status: StatusCode, payload: &[u8]) -> Result<AppendRowsResult, Error> {
+fn map_failed_response(err: crate::protocol::ErrorStatus) -> Error {
+    err.into_error(ErrorKind::Unexpected)
+}
+
+fn decode_append_response(
+    status: StatusCode,
+    headers: &reqwest::header::HeaderMap,
+    payload: &[u8],
+) -> Result<AppendRowsResult, Error> {
     if status == StatusCode::OK {
         return match serde_json::from_slice::<AppendRowsResult>(payload) {
             Ok(result)
@@ -386,46 +525,59 @@ fn decode_append_response(status: StatusCode, payload: &[u8]) -> Result<AppendRo
             {
                 Ok(result)
             }
-            Ok(_) => Err(append_unknown_error(
-                "table append response has an invalid body",
+            Ok(_) => Err(apply_response_metadata(
+                append_unknown_error("table append response has an invalid body"),
+                status,
+                headers,
             )),
-            Err(err) => {
-                Err(append_unknown_error("failed to decode table append response").set_source(err))
-            }
+            Err(err) => Err(apply_response_metadata(
+                append_unknown_error("failed to decode table append response").set_source(err),
+                status,
+                headers,
+            )),
         };
     }
 
     if status.is_success() {
-        return Err(append_unknown_error(format!(
-            "table append returned unexpected success status {}",
-            status.as_u16()
-        )));
+        return Err(apply_response_metadata(
+            append_unknown_error(format!(
+                "table append returned unexpected success status {}",
+                status.as_u16()
+            )),
+            status,
+            headers,
+        ));
     }
 
+    let http_error = crate::protocol::ErrorStatus::from_http_parts(status, headers, payload);
     if let Ok(payload) = serde_json::from_slice::<AppendRowsErrorPayload>(payload) {
         if matches!(
             payload.details.append_state,
             AppendState::Rejected | AppendState::Unknown
         ) {
             let append_state = payload.details.append_state;
-            let error = Error::new(
-                ErrorKind::AppendRowsFailed,
-                format_http_error(status, &payload.message),
-            )
-            .set_append_details(payload.details);
+            let error = http_error
+                .into_error(ErrorKind::AppendRowsFailed)
+                .set_append_details(payload.details);
 
             return Err(if append_state == AppendState::Unknown {
                 error.set_persistent()
-            } else if is_temporary_http_status(status) {
-                error.set_temporary()
             } else {
-                error.set_permanent()
+                error
             });
         }
     }
 
-    let message = http_error_message(payload);
-    Err(append_unknown_error(format_http_error(status, &message)))
+    let metadata_error = http_error.into_error(ErrorKind::AppendRowsFailed);
+    let mut error =
+        append_unknown_error(metadata_error.message().to_string()).set_http_status(status);
+    if let Some(request_id) = metadata_error.request_id() {
+        error = error.set_request_id(request_id.to_string());
+    }
+    if let Some(retry_after) = metadata_error.retry_after() {
+        error = error.set_retry_after(retry_after);
+    }
+    Err(error)
 }
 
 fn append_unknown_error(message: impl Into<String>) -> Error {
@@ -438,30 +590,19 @@ fn append_unknown_error(message: impl Into<String>) -> Error {
         .set_persistent()
 }
 
-fn is_temporary_http_status(status: StatusCode) -> bool {
-    matches!(
-        status,
-        StatusCode::REQUEST_TIMEOUT | StatusCode::TOO_MANY_REQUESTS
-    ) || status.is_server_error()
-}
-
-fn format_http_error(status: StatusCode, message: &str) -> String {
-    format!(
-        "{} ({}): {}",
-        status.canonical_reason().unwrap_or("Unknown"),
-        status.as_u16(),
-        message
-    )
-}
-
 #[cfg(test)]
 mod tests {
     use reqwest::StatusCode;
+    use reqwest::header::HeaderMap;
 
     use super::Client;
     use super::decode_append_response;
     use crate::ErrorKind;
     use crate::protocol::AppendState;
+
+    fn decode(status: StatusCode, payload: &[u8]) -> Result<crate::AppendRowsResult, crate::Error> {
+        decode_append_response(status, &HeaderMap::new(), payload)
+    }
 
     #[test]
     fn resource_url_preserves_base_path_and_encodes_segments() {
@@ -478,8 +619,25 @@ mod tests {
     }
 
     #[test]
+    fn client_builder_validates_and_redacts_api_keys() {
+        let builder = Client::builder("https://example.com").api_key("secret-api-key");
+        assert!(!format!("{builder:?}").contains("secret-api-key"));
+        let client = Client::builder("https://example.com")
+            .api_key("secret-api-key")
+            .build()
+            .unwrap();
+        assert!(!format!("{client:?}").contains("secret-api-key"));
+
+        let error = Client::builder("https://example.com")
+            .api_key("")
+            .build()
+            .unwrap_err();
+        assert_eq!(error.kind(), ErrorKind::ConfigInvalid);
+    }
+
+    #[test]
     fn committed_append_response_is_returned() {
-        let result = decode_append_response(
+        let result = decode(
             StatusCode::OK,
             br#"{"append_state":"committed","num_rows_inserted":2}"#,
         )
@@ -491,7 +649,7 @@ mod tests {
 
     #[test]
     fn rejected_append_error_preserves_row_details_and_retry_status() {
-        let error = decode_append_response(
+        let error = decode(
             StatusCode::SERVICE_UNAVAILABLE,
             br#"{
                 "message":"validation failed",
@@ -511,8 +669,32 @@ mod tests {
     }
 
     #[test]
-    fn unknown_append_outcome_is_never_retryable() {
+    fn append_error_preserves_server_message_and_http_metadata() {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-request-id", "header-request".parse().unwrap());
+        headers.insert(reqwest::header::RETRY_AFTER, "3".parse().unwrap());
         let error = decode_append_response(
+            StatusCode::SERVICE_UNAVAILABLE,
+            &headers,
+            br#"{
+                "message":"capacity is temporarily unavailable",
+                "request_id":"body-request",
+                "retryable":false,
+                "append_state":"rejected"
+            }"#,
+        )
+        .unwrap_err();
+
+        assert_eq!(error.message(), "capacity is temporarily unavailable");
+        assert_eq!(error.http_status(), Some(StatusCode::SERVICE_UNAVAILABLE));
+        assert_eq!(error.request_id(), Some("body-request"));
+        assert_eq!(error.retry_after(), Some(std::time::Duration::from_secs(3)));
+        assert!(!error.is_retryable());
+    }
+
+    #[test]
+    fn unknown_append_outcome_is_never_retryable() {
+        let error = decode(
             StatusCode::SERVICE_UNAVAILABLE,
             br#"{"message":"coordinator unavailable","append_state":"unknown"}"#,
         )
@@ -528,9 +710,7 @@ mod tests {
 
     #[test]
     fn unstructured_append_error_is_treated_as_unknown() {
-        let error =
-            decode_append_response(StatusCode::BAD_REQUEST, br#"{"message":"bad request"}"#)
-                .unwrap_err();
+        let error = decode(StatusCode::BAD_REQUEST, br#"{"message":"bad request"}"#).unwrap_err();
 
         assert!(error.is_persistent());
         assert_eq!(
@@ -541,13 +721,13 @@ mod tests {
 
     #[test]
     fn nested_append_error_has_clean_message_and_unknown_outcome() {
-        let error = decode_append_response(
+        let error = decode(
             StatusCode::NOT_FOUND,
             br#"{"error":{"message":"unsupported path"}}"#,
         )
         .unwrap_err();
 
-        assert_eq!(error.message(), "Not Found (404): unsupported path");
+        assert_eq!(error.message(), "unsupported path");
         assert!(error.is_persistent());
         assert_eq!(
             error.append_details().unwrap().append_state,

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -550,22 +550,22 @@ fn decode_append_response(
     }
 
     let http_error = crate::protocol::ErrorStatus::from_http_parts(status, headers, payload);
-    if let Ok(payload) = serde_json::from_slice::<AppendRowsErrorPayload>(payload) {
-        if matches!(
+    if let Ok(payload) = serde_json::from_slice::<AppendRowsErrorPayload>(payload)
+        && matches!(
             payload.details.append_state,
             AppendState::Rejected | AppendState::Unknown
-        ) {
-            let append_state = payload.details.append_state;
-            let error = http_error
-                .into_error(ErrorKind::AppendRowsFailed)
-                .set_append_details(payload.details);
+        )
+    {
+        let append_state = payload.details.append_state;
+        let error = http_error
+            .into_error(ErrorKind::AppendRowsFailed)
+            .set_append_details(payload.details);
 
-            return Err(if append_state == AppendState::Unknown {
-                error.set_persistent()
-            } else {
-                error
-            });
-        }
+        return Err(if append_state == AppendState::Unknown {
+            error.set_persistent()
+        } else {
+            error
+        });
     }
 
     let metadata_error = http_error.into_error(ErrorKind::AppendRowsFailed);

--- a/rust/src/error.rs
+++ b/rust/src/error.rs
@@ -13,6 +13,9 @@
 // limitations under the License.
 
 use std::fmt;
+use std::time::Duration;
+
+use reqwest::StatusCode;
 
 use crate::protocol::AppendErrorDetails;
 
@@ -29,6 +32,9 @@ pub enum ErrorKind {
 
     /// A table append was rejected or its commit outcome is unknown.
     AppendRowsFailed,
+
+    /// A statement reached a failed or cancelled terminal state.
+    StatementFailed,
 }
 
 impl ErrorKind {
@@ -50,6 +56,7 @@ impl From<ErrorKind> for &'static str {
             ErrorKind::Unexpected => "Unexpected",
             ErrorKind::ConfigInvalid => "ConfigInvalid",
             ErrorKind::AppendRowsFailed => "AppendRowsFailed",
+            ErrorKind::StatementFailed => "StatementFailed",
         }
     }
 }
@@ -76,6 +83,13 @@ enum ErrorStatus {
     Persistent,
 }
 
+#[derive(Debug, Default)]
+struct HttpErrorMetadata {
+    status: Option<StatusCode>,
+    request_id: Option<String>,
+    retry_after: Option<Duration>,
+}
+
 impl fmt::Display for ErrorStatus {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
@@ -93,6 +107,7 @@ pub struct Error {
     status: ErrorStatus,
     context: Vec<(&'static str, String)>,
     append_details: Option<AppendErrorDetails>,
+    http_metadata: Option<Box<HttpErrorMetadata>>,
 
     source: Option<anyhow::Error>,
 }
@@ -119,6 +134,16 @@ impl fmt::Display for Error {
             write!(f, " => {}", self.message)?;
         }
 
+        if let Some(status) = self.http_status() {
+            write!(f, ", http_status: {}", status.as_u16())?;
+        }
+        if let Some(request_id) = self.request_id() {
+            write!(f, ", request_id: {request_id}")?;
+        }
+        if let Some(retry_after) = self.retry_after() {
+            write!(f, ", retry_after: {retry_after:?}")?;
+        }
+
         if let Some(source) = &self.source {
             write!(f, ", source: {source}")?;
         }
@@ -137,6 +162,7 @@ impl fmt::Debug for Error {
             de.field("status", &self.status);
             de.field("context", &self.context);
             de.field("append_details", &self.append_details);
+            de.field("http_metadata", &self.http_metadata);
             de.field("source", &self.source);
             return de.finish();
         }
@@ -144,6 +170,15 @@ impl fmt::Debug for Error {
         write!(f, "{} ({})", self.kind, self.status)?;
         if !self.message.is_empty() {
             write!(f, " => {}", self.message)?;
+        }
+        if let Some(status) = self.http_status() {
+            write!(f, ", http_status: {}", status.as_u16())?;
+        }
+        if let Some(request_id) = self.request_id() {
+            write!(f, ", request_id: {request_id}")?;
+        }
+        if let Some(retry_after) = self.retry_after() {
+            write!(f, ", retry_after: {retry_after:?}")?;
         }
         writeln!(f)?;
 
@@ -180,6 +215,7 @@ impl Error {
             status: ErrorStatus::Permanent,
             context: Vec::default(),
             append_details: None,
+            http_metadata: None,
             source: None,
         }
     }
@@ -212,6 +248,26 @@ impl Error {
         self
     }
 
+    pub(crate) fn set_http_status(mut self, status: StatusCode) -> Self {
+        self.http_metadata_mut().status = Some(status);
+        self
+    }
+
+    pub(crate) fn set_request_id(mut self, request_id: String) -> Self {
+        self.http_metadata_mut().request_id = Some(request_id);
+        self
+    }
+
+    pub(crate) fn set_retry_after(mut self, retry_after: Duration) -> Self {
+        self.http_metadata_mut().retry_after = Some(retry_after);
+        self
+    }
+
+    fn http_metadata_mut(&mut self) -> &mut HttpErrorMetadata {
+        self.http_metadata
+            .get_or_insert_with(|| Box::new(HttpErrorMetadata::default()))
+    }
+
     /// Set permanent status for error.
     pub fn set_permanent(mut self) -> Self {
         self.status = ErrorStatus::Permanent;
@@ -242,6 +298,32 @@ impl Error {
     /// Return the error message.
     pub fn message(&self) -> &str {
         &self.message
+    }
+
+    /// Return the HTTP response status when the error came from a server.
+    pub fn http_status(&self) -> Option<StatusCode> {
+        self.http_metadata
+            .as_ref()
+            .and_then(|metadata| metadata.status)
+    }
+
+    /// Return the request identifier supplied by ScopeDB or an intermediary.
+    pub fn request_id(&self) -> Option<&str> {
+        self.http_metadata
+            .as_ref()
+            .and_then(|metadata| metadata.request_id.as_deref())
+    }
+
+    /// Return the delay suggested by the HTTP `Retry-After` header.
+    pub fn retry_after(&self) -> Option<Duration> {
+        self.http_metadata
+            .as_ref()
+            .and_then(|metadata| metadata.retry_after)
+    }
+
+    /// Return whether retrying this operation is currently appropriate.
+    pub fn is_retryable(&self) -> bool {
+        self.is_temporary()
     }
 
     /// Check if this error is temporary.

--- a/rust/src/ingest_stream.rs
+++ b/rust/src/ingest_stream.rs
@@ -416,11 +416,18 @@ async fn run_batch_worker<F>(
                         }
                         current_bytes = current_bytes.saturating_add(record.payload.len());
                         rows.push(record);
-                        if !rows.is_empty() && current_bytes >= batch_bytes {
-                            if let Err(err) = flush_pending(&mut rows, &mut current_bytes, retry, &mut flush_fn).await {
-                                *fatal.lock().await = Some(FatalState::from_error(&err));
-                                break;
-                            }
+                        if !rows.is_empty()
+                            && current_bytes >= batch_bytes
+                            && let Err(err) = flush_pending(
+                                &mut rows,
+                                &mut current_bytes,
+                                retry,
+                                &mut flush_fn,
+                            )
+                            .await
+                        {
+                            *fatal.lock().await = Some(FatalState::from_error(&err));
+                            break;
                         }
                     }
                     BatchCommand::Flush(ack) => {

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 mod append_stream;
+mod catalog;
 mod client;
 mod error;
 mod ingest_stream;
@@ -36,7 +37,9 @@ pub use append_stream::AppendStreamBuilder;
 pub use append_stream::AppendStreamState;
 pub use append_stream::AppendStreamStats;
 pub use append_stream::AppendTrySendError;
+pub use catalog::CatalogIterator;
 pub use client::Client;
+pub use client::ClientBuilder;
 pub use error::Error;
 pub use error::ErrorKind;
 pub use ingest_stream::IngestStream;
@@ -68,6 +71,7 @@ pub use protocol::TableSpec;
 /// The HTTP client version used by this SDK.
 pub use reqwest;
 pub use result::FieldSchema;
+pub use result::ResultObject;
 pub use result::ResultSet;
 pub use result::Schema;
 pub use result::Value;

--- a/rust/src/protocol.rs
+++ b/rust/src/protocol.rs
@@ -14,9 +14,12 @@
 
 use std::fmt;
 use std::str::FromStr;
+use std::time::Duration;
+use std::time::SystemTime;
 
 use jiff::SignedDuration;
 use reqwest::StatusCode;
+use reqwest::header::HeaderMap;
 use serde::Deserialize;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
@@ -75,7 +78,8 @@ pub struct AppendErrorDetails {
 
 #[derive(Debug, Clone, Deserialize)]
 pub(crate) struct AppendRowsErrorPayload {
-    pub message: String,
+    #[serde(rename = "message")]
+    pub _message: String,
     #[serde(flatten)]
     pub details: AppendErrorDetails,
 }
@@ -89,6 +93,21 @@ pub struct CatalogListOptions {
     /// Opaque token returned as `next_page_token` by the previous page.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub page_token: Option<String>,
+}
+
+impl CatalogListOptions {
+    pub(crate) fn validate(&self) -> Result<(), Error> {
+        if self
+            .page_size
+            .is_some_and(|size| !(1..=1000).contains(&size))
+        {
+            return Err(Error::new(
+                ErrorKind::ConfigInvalid,
+                "catalog page_size must be an integer from 1 to 1000",
+            ));
+        }
+        Ok(())
+    }
 }
 
 /// One page of catalog resources.
@@ -179,19 +198,29 @@ pub enum Response<T> {
 
 impl<T: DeserializeOwned> Response<T> {
     pub async fn from_http_response(r: reqwest::Response) -> Result<Self, Error> {
-        let make_error = |err| {
-            Error::new(ErrorKind::Unexpected, "failed to make response".to_string()).set_source(err)
-        };
-
         let code = r.status();
+        let headers = r.headers().clone();
+        let payload = r.bytes().await.map_err(|err| {
+            apply_response_metadata(
+                Error::new(ErrorKind::Unexpected, "failed to read response body").set_source(err),
+                code,
+                &headers,
+            )
+        })?;
         if code.is_success() {
-            let result = r.json().await.map_err(make_error)?;
+            let result = serde_json::from_slice(&payload).map_err(|err| {
+                apply_response_metadata(
+                    Error::new(ErrorKind::Unexpected, "failed to decode response body")
+                        .set_source(err),
+                    code,
+                    &headers,
+                )
+            })?;
             return Ok(Response::Success(result));
         }
 
-        let payload = r.bytes().await.map_err(make_error)?;
-        Ok(Response::Failed(ErrorStatus::from_http_payload(
-            code, &payload,
+        Ok(Response::Failed(ErrorStatus::from_http_parts(
+            code, &headers, &payload,
         )))
     }
 }
@@ -200,38 +229,112 @@ impl<T: DeserializeOwned> Response<T> {
 pub struct ErrorStatus {
     code: StatusCode,
     message: String,
+    request_id: Option<String>,
+    retry_after: Option<Duration>,
+    retryable: Option<bool>,
 }
 
 impl ErrorStatus {
-    pub(crate) fn from_http_payload(code: StatusCode, payload: &[u8]) -> Self {
+    pub(crate) fn from_http_parts(code: StatusCode, headers: &HeaderMap, payload: &[u8]) -> Self {
+        let parsed = parse_error_payload(payload);
         Self {
             code,
-            message: http_error_message(payload),
+            message: parsed
+                .as_ref()
+                .map(|parsed| parsed.message.clone())
+                .unwrap_or_else(|| String::from_utf8_lossy(payload).into_owned()),
+            request_id: parsed
+                .as_ref()
+                .and_then(|parsed| parsed.request_id.clone())
+                .or_else(|| header_string(headers, "x-request-id")),
+            retry_after: parse_retry_after(headers, SystemTime::now()),
+            retryable: parsed.and_then(|parsed| parsed.retryable),
         }
     }
 
-    pub fn code(&self) -> StatusCode {
-        self.code
+    pub(crate) fn into_error(self, kind: ErrorKind) -> Error {
+        let mut error = Error::new(kind, self.message).set_http_status(self.code);
+        if let Some(request_id) = self.request_id {
+            error = error.set_request_id(request_id);
+        }
+        if let Some(retry_after) = self.retry_after {
+            error = error.set_retry_after(retry_after);
+        }
+        let retryable = self.retryable.unwrap_or_else(|| {
+            matches!(
+                self.code,
+                StatusCode::REQUEST_TIMEOUT | StatusCode::TOO_MANY_REQUESTS
+            ) || self.code.is_server_error()
+        });
+        if retryable {
+            error.set_temporary()
+        } else {
+            error.set_permanent()
+        }
     }
 }
 
-pub(crate) fn http_error_message(payload: &[u8]) -> String {
-    if let Ok(payload) = serde_json::from_slice::<serde_json::Value>(payload) {
-        let message = payload
-            .get("message")
-            .and_then(serde_json::Value::as_str)
-            .or_else(|| {
-                payload
-                    .get("error")
-                    .and_then(|error| error.get("message"))
-                    .and_then(serde_json::Value::as_str)
-            });
-        if let Some(message) = message {
-            return message.to_string();
-        }
+#[derive(Debug)]
+struct ParsedErrorPayload {
+    message: String,
+    request_id: Option<String>,
+    retryable: Option<bool>,
+}
+
+fn parse_error_payload(payload: &[u8]) -> Option<ParsedErrorPayload> {
+    let payload = serde_json::from_slice::<serde_json::Value>(payload).ok()?;
+    let object = payload.as_object()?;
+    if let Some(message) = object.get("message").and_then(serde_json::Value::as_str) {
+        return Some(ParsedErrorPayload {
+            message: message.to_string(),
+            request_id: object
+                .get("request_id")
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_string),
+            retryable: object.get("retryable").and_then(serde_json::Value::as_bool),
+        });
     }
 
-    String::from_utf8_lossy(payload).into_owned()
+    let nested = object.get("error")?.as_object()?;
+    Some(ParsedErrorPayload {
+        message: nested.get("message")?.as_str()?.to_string(),
+        request_id: object
+            .get("request_id")
+            .and_then(serde_json::Value::as_str)
+            .map(str::to_string),
+        retryable: nested.get("retryable").and_then(serde_json::Value::as_bool),
+    })
+}
+
+pub(crate) fn apply_response_metadata(
+    mut error: Error,
+    status: StatusCode,
+    headers: &HeaderMap,
+) -> Error {
+    error = error.set_http_status(status);
+    if let Some(request_id) = header_string(headers, "x-request-id") {
+        error = error.set_request_id(request_id);
+    }
+    if let Some(retry_after) = parse_retry_after(headers, SystemTime::now()) {
+        error = error.set_retry_after(retry_after);
+    }
+    error
+}
+
+fn header_string(headers: &HeaderMap, name: &'static str) -> Option<String> {
+    headers
+        .get(name)
+        .and_then(|value| value.to_str().ok())
+        .map(str::to_string)
+}
+
+fn parse_retry_after(headers: &HeaderMap, now: SystemTime) -> Option<Duration> {
+    let value = headers.get(reqwest::header::RETRY_AFTER)?.to_str().ok()?;
+    if let Ok(seconds) = value.parse::<u64>() {
+        return Some(Duration::from_secs(seconds));
+    }
+    let at = httpdate::parse_http_date(value).ok()?;
+    Some(at.duration_since(now).unwrap_or(Duration::ZERO))
 }
 
 impl fmt::Display for ErrorStatus {
@@ -559,11 +662,21 @@ impl FromStr for DataType {
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+    use std::time::SystemTime;
+
+    use reqwest::header::HeaderMap;
+    use reqwest::header::HeaderValue;
+
     use super::AppendRowsErrorPayload;
     use super::AppendState;
+    use super::CatalogListOptions;
     use super::DataType;
+    use super::ErrorStatus;
     use super::TableResource;
-    use super::http_error_message;
+    use super::parse_error_payload;
+    use super::parse_retry_after;
+    use crate::ErrorKind;
 
     #[test]
     fn append_error_details_use_wire_defaults() {
@@ -579,13 +692,72 @@ mod tests {
     #[test]
     fn http_error_message_supports_direct_and_nested_payloads() {
         assert_eq!(
-            http_error_message(br#"{"message":"direct failure","error":"details"}"#),
+            parse_error_payload(br#"{"message":"direct failure","error":"details"}"#)
+                .unwrap()
+                .message,
             "direct failure"
         );
         assert_eq!(
-            http_error_message(br#"{"error":{"message":"nested failure"}}"#),
+            parse_error_payload(br#"{"error":{"message":"nested failure"}}"#)
+                .unwrap()
+                .message,
             "nested failure"
         );
+    }
+
+    #[test]
+    fn http_error_metadata_prefers_payload_and_honors_retryable() {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-request-id", HeaderValue::from_static("header-request"));
+        headers.insert(reqwest::header::RETRY_AFTER, HeaderValue::from_static("7"));
+
+        let error = ErrorStatus::from_http_parts(
+            reqwest::StatusCode::SERVICE_UNAVAILABLE,
+            &headers,
+            br#"{"message":"busy","request_id":"body-request","retryable":false}"#,
+        )
+        .into_error(ErrorKind::Unexpected);
+
+        assert_eq!(error.message(), "busy");
+        assert_eq!(
+            error.http_status(),
+            Some(reqwest::StatusCode::SERVICE_UNAVAILABLE)
+        );
+        assert_eq!(error.request_id(), Some("body-request"));
+        assert_eq!(error.retry_after(), Some(Duration::from_secs(7)));
+        assert!(!error.is_retryable());
+
+        let nested = ErrorStatus::from_http_parts(
+            reqwest::StatusCode::BAD_REQUEST,
+            &HeaderMap::new(),
+            br#"{"error":{"message":"try later","retryable":true}}"#,
+        )
+        .into_error(ErrorKind::Unexpected);
+        assert_eq!(nested.message(), "try later");
+        assert!(nested.is_retryable());
+    }
+
+    #[test]
+    fn retry_after_accepts_http_dates() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            reqwest::header::RETRY_AFTER,
+            HeaderValue::from_static("Thu, 01 Jan 1970 00:00:10 GMT"),
+        );
+        assert_eq!(
+            parse_retry_after(&headers, SystemTime::UNIX_EPOCH),
+            Some(Duration::from_secs(10))
+        );
+    }
+
+    #[test]
+    fn catalog_page_size_is_validated_locally() {
+        let options = CatalogListOptions {
+            page_size: Some(1001),
+            page_token: None,
+        };
+        let error = options.validate().unwrap_err();
+        assert_eq!(error.kind(), ErrorKind::ConfigInvalid);
     }
 
     #[test]

--- a/rust/src/result.rs
+++ b/rust/src/result.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::BTreeMap;
+use std::collections::HashSet;
 use std::fmt;
 use std::str::FromStr;
 
@@ -55,6 +57,9 @@ pub struct ResultSet {
     data: ResultSetData,
 }
 
+/// One typed result row keyed by its ScopeQL output column name.
+pub type ResultObject = BTreeMap<String, Value>;
+
 impl ResultSet {
     pub fn num_rows(&self) -> usize {
         self.num_rows
@@ -64,85 +69,171 @@ impl ResultSet {
         &self.schema
     }
 
-    pub fn json_rows(&self) -> Option<&[Vec<Option<String>>]> {
+    /// Returns the unparsed JSON-format cells exactly as received from ScopeDB.
+    pub fn raw_rows(&self) -> &[Vec<Option<String>>] {
         match &self.data {
-            ResultSetData::Json { rows } => Some(rows),
+            ResultSetData::Json { rows } => rows,
         }
     }
 
+    /// Backward-compatible alias for [`ResultSet::raw_rows`].
+    #[deprecated(note = "use raw_rows")]
+    pub fn json_rows(&self) -> Option<&[Vec<Option<String>>]> {
+        Some(self.raw_rows())
+    }
+
+    /// Converts all result cells to their typed Rust representation.
+    pub fn to_values(&self) -> Result<Vec<Vec<Value>>, Error> {
+        self.validate_shape()?;
+        self.raw_rows()
+            .iter()
+            .map(|row| {
+                row.iter()
+                    .zip(self.schema.fields.iter())
+                    .map(|(cell, field)| parse_cell(cell.as_deref(), field.data_type()))
+                    .collect()
+            })
+            .collect()
+    }
+
+    /// Consumes the result set and returns typed rows.
     pub fn into_values(self) -> Result<Vec<Vec<Value>>, Error> {
-        let rows = match self.data {
+        self.validate_shape()?;
+        let ResultSet { schema, data, .. } = self;
+        let rows = match data {
             ResultSetData::Json { rows } => rows,
         };
+        rows.into_iter()
+            .map(|row| {
+                row.into_iter()
+                    .zip(schema.fields.iter())
+                    .map(|(cell, field)| parse_owned_cell(cell, field.data_type()))
+                    .collect()
+            })
+            .collect()
+    }
 
-        let num_rows = self.num_rows;
-        let num_fields = self.schema.fields.len();
-        assert_eq!(rows.len(), num_rows);
+    /// Converts all rows to maps keyed by unique output column names.
+    ///
+    /// Duplicate output names are rejected instead of silently discarding a
+    /// value. Use [`ResultSet::to_values`] when a query intentionally returns
+    /// duplicate column names.
+    pub fn to_objects(&self) -> Result<Vec<ResultObject>, Error> {
+        self.validate_unique_fields()?;
+        self.to_values().map(|rows| {
+            rows.into_iter()
+                .map(|row| {
+                    self.schema
+                        .fields
+                        .iter()
+                        .map(|field| field.name.clone())
+                        .zip(row)
+                        .collect()
+                })
+                .collect()
+        })
+    }
 
-        let mut values = Vec::with_capacity(num_rows);
-        for row in rows {
-            assert_eq!(row.len(), num_fields);
+    /// Consumes the result set and returns rows keyed by output column name.
+    pub fn into_objects(self) -> Result<Vec<ResultObject>, Error> {
+        self.validate_unique_fields()?;
+        self.validate_shape()?;
+        let ResultSet { schema, data, .. } = self;
+        let names = schema
+            .fields
+            .iter()
+            .map(|field| field.name.clone())
+            .collect::<Vec<_>>();
+        let rows = match data {
+            ResultSetData::Json { rows } => rows,
+        };
+        rows.into_iter()
+            .map(|row| {
+                row.into_iter()
+                    .zip(schema.fields.iter())
+                    .map(|(cell, field)| parse_owned_cell(cell, field.data_type()))
+                    .collect::<Result<Vec<_>, _>>()
+                    .map(|values| names.iter().cloned().zip(values).collect())
+            })
+            .collect()
+    }
 
-            let mut value_row = Vec::with_capacity(num_fields);
-            for (i, cell) in row.into_iter().enumerate() {
-                let Some(value) = cell else {
-                    value_row.push(Value::Null);
-                    continue;
-                };
+    /// Returns the first row keyed by output column name, or `None` when empty.
+    pub fn first(&self) -> Result<Option<ResultObject>, Error> {
+        let Some(row) = self.raw_rows().first() else {
+            return Ok(None);
+        };
+        self.validate_unique_fields()?;
+        self.validate_row_shape(0, row)?;
+        let values = row
+            .iter()
+            .zip(self.schema.fields.iter())
+            .map(|(cell, field)| parse_cell(cell.as_deref(), field.data_type()))
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(Some(
+            self.schema
+                .fields
+                .iter()
+                .map(|field| field.name.clone())
+                .zip(values)
+                .collect(),
+        ))
+    }
 
-                let value = match self.schema.fields[i].data_type() {
-                    DataType::Int => Value::Int(i64::from_str(&value).map_err(|err| {
-                        Error::new(
-                            ErrorKind::Unexpected,
-                            format!("failed to parse int value: {err}"),
-                        )
-                    })?),
-                    DataType::UInt => Value::UInt(u64::from_str(&value).map_err(|err| {
-                        Error::new(
-                            ErrorKind::Unexpected,
-                            format!("failed to parse uint value: {err}"),
-                        )
-                    })?),
-                    DataType::Float => Value::Float(f64::from_str(&value).map_err(|err| {
-                        Error::new(
-                            ErrorKind::Unexpected,
-                            format!("failed to parse float value: {err}"),
-                        )
-                    })?),
-                    DataType::Timestamp => {
-                        Value::Timestamp(jiff::Timestamp::from_str(&value).map_err(|err| {
-                            Error::new(
-                                ErrorKind::Unexpected,
-                                format!("failed to parse timestamp value: {err}"),
-                            )
-                        })?)
-                    }
-                    DataType::Interval => {
-                        Value::Interval(jiff::SignedDuration::from_str(&value).map_err(|err| {
-                            Error::new(
-                                ErrorKind::Unexpected,
-                                format!("failed to parse interval value: {err}"),
-                            )
-                        })?)
-                    }
-                    DataType::Boolean => Value::Boolean(bool::from_str(&value).map_err(|err| {
-                        Error::new(
-                            ErrorKind::Unexpected,
-                            format!("failed to parse boolean value: {err}"),
-                        )
-                    })?),
-                    DataType::String => Value::String(value),
-                    DataType::Binary => Value::Binary(value),
-                    DataType::Array => Value::Array(value),
-                    DataType::Object => Value::Object(value),
-                    DataType::Any => Value::Any(value),
-                    DataType::Null => unreachable!("null values must be None in rows"),
-                };
-                value_row.push(value);
-            }
-            values.push(value_row);
+    fn validate_shape(&self) -> Result<(), Error> {
+        let rows = self.raw_rows();
+        if rows.len() != self.num_rows {
+            return Err(Error::new(
+                ErrorKind::Unexpected,
+                format!(
+                    "result row count mismatch: expected {}, got {}",
+                    self.num_rows,
+                    rows.len()
+                ),
+            ));
         }
-        Ok(values)
+        let expected = self.schema.fields.len();
+        if let Some((index, row)) = rows
+            .iter()
+            .enumerate()
+            .find(|(_, row)| row.len() != expected)
+        {
+            return self.validate_row_shape(index, row);
+        }
+        Ok(())
+    }
+
+    fn validate_row_shape(&self, index: usize, row: &[Option<String>]) -> Result<(), Error> {
+        let expected = self.schema.fields.len();
+        if row.len() == expected {
+            return Ok(());
+        }
+        Err(Error::new(
+            ErrorKind::Unexpected,
+            format!(
+                "result row {index} field count mismatch: expected {expected}, got {}",
+                row.len()
+            ),
+        ))
+    }
+
+    fn validate_unique_fields(&self) -> Result<(), Error> {
+        let mut names = HashSet::with_capacity(self.schema.fields.len());
+        if let Some(field) = self
+            .schema
+            .fields
+            .iter()
+            .find(|field| !names.insert(field.name.as_str()))
+        {
+            return Err(Error::new(
+                ErrorKind::Unexpected,
+                format!(
+                    "cannot convert result to objects because column name {:?} is duplicated; use to_values instead",
+                    field.name
+                ),
+            ));
+        }
+        Ok(())
     }
 
     pub(crate) fn from_statement_result_set(result_set: StatementResultSet) -> ResultSet {
@@ -161,6 +252,79 @@ impl ResultSet {
             },
             data: result_set.data,
         }
+    }
+}
+
+fn parse_cell(value: Option<&str>, data_type: DataType) -> Result<Value, Error> {
+    let Some(value) = value else {
+        return Ok(Value::Null);
+    };
+
+    match data_type {
+        DataType::Int => i64::from_str(value).map(Value::Int).map_err(|err| {
+            Error::new(
+                ErrorKind::Unexpected,
+                format!("failed to parse int value: {err}"),
+            )
+        }),
+        DataType::UInt => u64::from_str(value).map(Value::UInt).map_err(|err| {
+            Error::new(
+                ErrorKind::Unexpected,
+                format!("failed to parse uint value: {err}"),
+            )
+        }),
+        DataType::Float => f64::from_str(value).map(Value::Float).map_err(|err| {
+            Error::new(
+                ErrorKind::Unexpected,
+                format!("failed to parse float value: {err}"),
+            )
+        }),
+        DataType::Timestamp => jiff::Timestamp::from_str(value)
+            .map(Value::Timestamp)
+            .map_err(|err| {
+                Error::new(
+                    ErrorKind::Unexpected,
+                    format!("failed to parse timestamp value: {err}"),
+                )
+            }),
+        DataType::Interval => jiff::SignedDuration::from_str(value)
+            .map(Value::Interval)
+            .map_err(|err| {
+                Error::new(
+                    ErrorKind::Unexpected,
+                    format!("failed to parse interval value: {err}"),
+                )
+            }),
+        DataType::Boolean => bool::from_str(value).map(Value::Boolean).map_err(|err| {
+            Error::new(
+                ErrorKind::Unexpected,
+                format!("failed to parse boolean value: {err}"),
+            )
+        }),
+        DataType::String => Ok(Value::String(value.to_string())),
+        DataType::Binary => Ok(Value::Binary(value.to_string())),
+        DataType::Array => Ok(Value::Array(value.to_string())),
+        DataType::Object => Ok(Value::Object(value.to_string())),
+        DataType::Any => Ok(Value::Any(value.to_string())),
+        DataType::Null => Err(Error::new(
+            ErrorKind::Unexpected,
+            "non-null cell returned for a null column",
+        )),
+    }
+}
+
+fn parse_owned_cell(value: Option<String>, data_type: DataType) -> Result<Value, Error> {
+    let Some(value) = value else {
+        return Ok(Value::Null);
+    };
+
+    match data_type {
+        DataType::String => Ok(Value::String(value)),
+        DataType::Binary => Ok(Value::Binary(value)),
+        DataType::Array => Ok(Value::Array(value)),
+        DataType::Object => Ok(Value::Object(value)),
+        DataType::Any => Ok(Value::Any(value)),
+        _ => parse_cell(Some(&value), data_type),
     }
 }
 
@@ -271,4 +435,121 @@ fn quote_string(f: &mut fmt::Formatter<'_>, s: &str, quote: char) -> fmt::Result
         }
     }
     write!(f, "{quote}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::protocol::FieldMetadata;
+    use crate::protocol::ResultSetMetadata;
+    use crate::protocol::StatementResultSet;
+
+    fn result(fields: Vec<(&str, DataType)>, rows: Vec<Vec<Option<&str>>>) -> ResultSet {
+        let num_rows = rows.len();
+        ResultSet::from_statement_result_set(StatementResultSet {
+            metadata: ResultSetMetadata {
+                fields: fields
+                    .into_iter()
+                    .map(|(name, data_type)| FieldMetadata {
+                        name: name.to_string(),
+                        data_type,
+                    })
+                    .collect(),
+                num_rows,
+            },
+            data: ResultSetData::Json {
+                rows: rows
+                    .into_iter()
+                    .map(|row| {
+                        row.into_iter()
+                            .map(|cell| cell.map(str::to_string))
+                            .collect()
+                    })
+                    .collect(),
+            },
+        })
+    }
+
+    #[test]
+    fn exposes_raw_values_objects_and_first_row() {
+        let result = result(
+            vec![("id", DataType::Int), ("name", DataType::String)],
+            vec![vec![Some("42"), Some("ScopeDB")]],
+        );
+
+        assert_eq!(result.raw_rows()[0][0].as_deref(), Some("42"));
+        let values = result.to_values().unwrap();
+        assert!(matches!(values[0][0], Value::Int(42)));
+        let objects = result.to_objects().unwrap();
+        assert!(matches!(objects[0].get("id"), Some(Value::Int(42))));
+        assert!(matches!(
+            result.first().unwrap().unwrap().get("name"),
+            Some(Value::String(value)) if value == "ScopeDB"
+        ));
+    }
+
+    #[test]
+    fn consuming_conversions_move_string_values() {
+        let values = result(
+            vec![("name", DataType::String)],
+            vec![vec![Some("ScopeDB")]],
+        )
+        .into_values()
+        .unwrap();
+        assert!(matches!(&values[0][0], Value::String(value) if value == "ScopeDB"));
+
+        let objects = result(
+            vec![("name", DataType::String)],
+            vec![vec![Some("ScopeDB")]],
+        )
+        .into_objects()
+        .unwrap();
+        assert!(matches!(
+            objects[0].get("name"),
+            Some(Value::String(value)) if value == "ScopeDB"
+        ));
+    }
+
+    #[test]
+    fn malformed_shapes_return_errors_instead_of_panicking() {
+        let mut malformed = result(
+            vec![("id", DataType::Int)],
+            vec![vec![Some("1"), Some("extra")]],
+        );
+        malformed.num_rows = 2;
+        let error = malformed.to_values().unwrap_err();
+        assert_eq!(error.kind(), ErrorKind::Unexpected);
+    }
+
+    #[test]
+    fn object_conversion_rejects_duplicate_names() {
+        let result = result(
+            vec![("value", DataType::Int), ("value", DataType::Int)],
+            vec![vec![Some("1"), Some("2")]],
+        );
+        let error = result.to_objects().unwrap_err();
+        assert!(error.message().contains("duplicated"));
+    }
+
+    #[test]
+    fn first_parses_only_the_first_row() {
+        let result = result(
+            vec![("id", DataType::Int)],
+            vec![vec![Some("1")], vec![Some("2"), Some("extra")]],
+        );
+        assert!(matches!(
+            result.first().unwrap().unwrap().get("id"),
+            Some(Value::Int(1))
+        ));
+        assert!(result.to_values().is_err());
+    }
+
+    #[test]
+    fn first_returns_none_for_empty_results_with_duplicate_names() {
+        let result = result(
+            vec![("value", DataType::Int), ("value", DataType::Int)],
+            vec![],
+        );
+        assert!(result.first().unwrap().is_none());
+    }
 }

--- a/rust/src/statement.rs
+++ b/rust/src/statement.rs
@@ -80,7 +80,7 @@ impl Statement {
                 client,
                 statement_id: response.statement_id(),
                 format,
-                status: Some(response),
+                last_status: Some(response),
             }),
             Response::Failed(err) => Err(err.into_error(ErrorKind::Unexpected)),
         }
@@ -107,7 +107,7 @@ pub struct StatementHandle {
     client: Client,
     statement_id: Uuid,
     format: ResultFormat,
-    status: Option<StatementStatus>,
+    last_status: Option<StatementStatus>,
 }
 
 impl StatementHandle {
@@ -115,29 +115,33 @@ impl StatementHandle {
         self.statement_id
     }
 
-    pub fn status(&self) -> Option<&StatementStatus> {
-        self.status.as_ref()
+    /// Returns the status snapshot received by the most recent request without
+    /// making a network request.
+    pub fn last_status(&self) -> Option<&StatementStatus> {
+        self.last_status.as_ref()
     }
 
+    /// Returns progress from the most recent status snapshot.
     pub fn progress(&self) -> Option<&crate::StatementEstimatedProgress> {
-        self.status.as_ref().map(StatementStatus::progress)
+        self.last_status.as_ref().map(StatementStatus::progress)
     }
 
+    /// Returns a result set when the most recent status snapshot is finished.
     pub fn result_set(&self) -> Option<ResultSet> {
-        self.status.as_ref().and_then(|status| match status {
+        self.last_status.as_ref().and_then(|status| match status {
             StatementStatus::Finished(s) => Some(s.result_set()),
             _ => None,
         })
     }
 
     /// Fetches and returns the latest statement status.
-    pub async fn refresh(&mut self) -> Result<&StatementStatus, Error> {
+    pub async fn status(&mut self) -> Result<&StatementStatus, Error> {
         // already terminated - no need to fetch again
-        match self.status.as_ref() {
+        match self.last_status.as_ref() {
             Some(StatementStatus::Finished(..))
             | Some(StatementStatus::Failed(..))
             | Some(StatementStatus::Cancelled(..)) => {
-                return Ok(self.status.as_ref().expect("status was matched above"));
+                return Ok(self.last_status.as_ref().expect("status was matched above"));
             }
             _ => {}
         }
@@ -149,17 +153,17 @@ impl StatementHandle {
             .await?
         {
             Response::Success(status) => {
-                self.status = Some(status);
-                Ok(self.status.as_ref().expect("status was just assigned"))
+                self.last_status = Some(status);
+                Ok(self.last_status.as_ref().expect("status was just assigned"))
             }
             Response::Failed(err) => Err(err.into_error(ErrorKind::Unexpected)),
         }
     }
 
-    /// Backward-compatible alias for [`StatementHandle::refresh`].
-    #[deprecated(note = "use refresh")]
+    /// Backward-compatible alias for [`StatementHandle::status`].
+    #[deprecated(note = "use status")]
     pub async fn fetch_once(&mut self) -> Result<(), Error> {
-        self.refresh().await.map(|_| ())
+        self.status().await.map(|_| ())
     }
 
     /// Waits for the statement to terminate and returns its result set.
@@ -168,9 +172,9 @@ impl StatementHandle {
         let max_delay = Duration::from_secs(1);
 
         loop {
-            self.refresh().await?;
+            self.status().await?;
 
-            if let Some(status) = self.status.as_ref() {
+            if let Some(status) = self.last_status.as_ref() {
                 match status {
                     StatementStatus::Finished(finished) => return Ok(finished.result_set()),
                     StatementStatus::Failed(failed) => {
@@ -203,7 +207,7 @@ impl StatementHandle {
     }
 
     pub async fn cancel(&mut self) -> Result<StatementCancelResult, Error> {
-        if let Some(response) = self.status.as_ref() {
+        if let Some(response) = self.last_status.as_ref() {
             match response {
                 StatementStatus::Pending(..) | StatementStatus::Running(..) => {}
                 StatementStatus::Finished(s) => {
@@ -235,7 +239,7 @@ impl StatementHandle {
 
         match self.client.cancel_statement(self.statement_id).await? {
             Response::Success(response) => {
-                self.status = match response.status.as_str() {
+                self.last_status = match response.status.as_str() {
                     "failed" => Some(StatementStatus::Failed(crate::StatementStatusFailed {
                         statement_id: response.statement_id,
                         created_at: response.created_at,
@@ -250,7 +254,7 @@ impl StatementHandle {
                             message: response.message.clone(),
                         },
                     )),
-                    _ => self.status.take(),
+                    _ => self.last_status.take(),
                 };
                 Ok(response)
             }
@@ -263,7 +267,7 @@ impl StatementHandle {
             client,
             statement_id,
             format,
-            status: None,
+            last_status: None,
         }
     }
 }

--- a/rust/src/statement.rs
+++ b/rust/src/statement.rs
@@ -82,15 +82,12 @@ impl Statement {
                 format,
                 status: Some(response),
             }),
-            Response::Failed(err) => Err(Error::new(
-                ErrorKind::Unexpected,
-                format!("failed to submit statement: {err}"),
-            )),
+            Response::Failed(err) => Err(err.into_error(ErrorKind::Unexpected)),
         }
     }
 
     pub async fn execute(self) -> Result<ResultSet, Error> {
-        self.submit().await?.fetch().await
+        self.submit().await?.wait().await
     }
 
     pub(crate) fn new(client: Client, statement: String) -> Self {
@@ -133,13 +130,14 @@ impl StatementHandle {
         })
     }
 
-    pub async fn fetch_once(&mut self) -> Result<(), Error> {
+    /// Fetches and returns the latest statement status.
+    pub async fn refresh(&mut self) -> Result<&StatementStatus, Error> {
         // already terminated - no need to fetch again
         match self.status.as_ref() {
             Some(StatementStatus::Finished(..))
             | Some(StatementStatus::Failed(..))
             | Some(StatementStatus::Cancelled(..)) => {
-                return Ok(());
+                return Ok(self.status.as_ref().expect("status was matched above"));
             }
             _ => {}
         }
@@ -152,30 +150,40 @@ impl StatementHandle {
         {
             Response::Success(status) => {
                 self.status = Some(status);
-                Ok(())
+                Ok(self.status.as_ref().expect("status was just assigned"))
             }
-            Response::Failed(err) => Err(Error::new(
-                ErrorKind::Unexpected,
-                format!("failed to fetch statement: {err}"),
-            )),
+            Response::Failed(err) => Err(err.into_error(ErrorKind::Unexpected)),
         }
     }
 
-    pub async fn fetch(&mut self) -> Result<ResultSet, Error> {
+    /// Backward-compatible alias for [`StatementHandle::refresh`].
+    #[deprecated(note = "use refresh")]
+    pub async fn fetch_once(&mut self) -> Result<(), Error> {
+        self.refresh().await.map(|_| ())
+    }
+
+    /// Waits for the statement to terminate and returns its result set.
+    pub async fn wait(&mut self) -> Result<ResultSet, Error> {
         let mut delay = Duration::from_millis(5);
         let max_delay = Duration::from_secs(1);
 
         loop {
-            self.fetch_once().await?;
+            self.refresh().await?;
 
             if let Some(status) = self.status.as_ref() {
                 match status {
                     StatementStatus::Finished(finished) => return Ok(finished.result_set()),
                     StatementStatus::Failed(failed) => {
-                        return Err(Error::new(ErrorKind::Unexpected, failed.message.clone()));
+                        return Err(Error::new(
+                            ErrorKind::StatementFailed,
+                            failed.message.clone(),
+                        ));
                     }
                     StatementStatus::Cancelled(cancelled) => {
-                        return Err(Error::new(ErrorKind::Unexpected, cancelled.message.clone()));
+                        return Err(Error::new(
+                            ErrorKind::StatementFailed,
+                            cancelled.message.clone(),
+                        ));
                     }
                     StatementStatus::Pending(..) | StatementStatus::Running(..) => {
                         sleep(delay).await;
@@ -186,6 +194,12 @@ impl StatementHandle {
                 }
             }
         }
+    }
+
+    /// Backward-compatible alias for [`StatementHandle::wait`].
+    #[deprecated(note = "use wait")]
+    pub async fn fetch(&mut self) -> Result<ResultSet, Error> {
+        self.wait().await
     }
 
     pub async fn cancel(&mut self) -> Result<StatementCancelResult, Error> {
@@ -240,10 +254,7 @@ impl StatementHandle {
                 };
                 Ok(response)
             }
-            Response::Failed(err) => Err(Error::new(
-                ErrorKind::Unexpected,
-                format!("failed to cancel statement: {err}"),
-            )),
+            Response::Failed(err) => Err(err.into_error(ErrorKind::Unexpected)),
         }
     }
 

--- a/rust/src/table.rs
+++ b/rust/src/table.rs
@@ -18,6 +18,7 @@ use crate::FieldSchema;
 use crate::Schema;
 use crate::append_stream::AppendStreamBuilder;
 use crate::protocol::AppendRowsResult;
+use crate::protocol::TableResource;
 
 #[derive(Debug, Clone)]
 pub struct Table {
@@ -91,13 +92,21 @@ impl Table {
         )
     }
 
+    /// Fetches the full REST catalog resource for this table.
+    pub async fn describe(&self) -> Result<TableResource, Error> {
+        self.client
+            .fetch_table(
+                self.database.as_deref().unwrap_or("scopedb"),
+                self.schema.as_deref().unwrap_or("public"),
+                &self.table,
+            )
+            .await
+    }
+
+    /// Backward-compatible schema-only view of [`Table::describe`].
+    #[deprecated(note = "use describe")]
     pub async fn table_schema(&self) -> Result<Schema, Error> {
-        let database_name = self.database.as_deref().unwrap_or("scopedb");
-        let schema_name = self.schema.as_deref().unwrap_or("public");
-        let table = self
-            .client
-            .fetch_table(database_name, schema_name, &self.table)
-            .await?;
+        let table = self.describe().await?;
         let fields = table
             .columns
             .into_iter()

--- a/rust/tests/public_api.rs
+++ b/rust/tests/public_api.rs
@@ -20,3 +20,32 @@ fn reexported_http_client_matches_constructor() {
     )
     .unwrap();
 }
+
+#[test]
+fn ergonomic_client_builder_is_public() {
+    scopedb_client::Client::builder("http://127.0.0.1:6543")
+        .api_key("test-key")
+        .http_client(scopedb_client::reqwest::Client::new())
+        .build()
+        .unwrap();
+}
+
+#[allow(dead_code)]
+fn application_api_surface_compiles(client: &scopedb_client::Client) {
+    let _query = client.query("SELECT 1");
+    let _databases = client.iterate_databases(scopedb_client::CatalogListOptions::default());
+    let _schemas = client.iterate_schemas("scopedb", scopedb_client::CatalogListOptions::default());
+    let _tables = client.iterate_tables(
+        "scopedb",
+        "public",
+        scopedb_client::CatalogListOptions::default(),
+    );
+    let table = client.table("events").with_schema("public");
+    let _description = table.describe();
+    let _stream = table
+        .append_stream()
+        .target_batch_bytes(1024)
+        .max_batch_rows(100)
+        .max_buffered_bytes(4096)
+        .max_concurrent_batches(2);
+}

--- a/rust/tests/public_api.rs
+++ b/rust/tests/public_api.rs
@@ -33,6 +33,12 @@ fn ergonomic_client_builder_is_public() {
 #[allow(dead_code)]
 fn application_api_surface_compiles(client: &scopedb_client::Client) {
     let _query = client.query("SELECT 1");
+    let mut handle = client.statement_handle(uuid::Uuid::nil());
+    let _last_status: Option<&scopedb_client::StatementStatus> = handle.last_status();
+    let status = handle.status();
+    drop(status);
+    let wait = handle.wait();
+    drop(wait);
     let _databases = client.iterate_databases(scopedb_client::CatalogListOptions::default());
     let _schemas = client.iterate_schemas("scopedb", scopedb_client::CatalogListOptions::default());
     let _tables = client.iterate_tables(


### PR DESCRIPTION
## Summary

- align the Rust SDK's application-facing path with the JS baseline through an API-key client builder, `Client::query`, typed/object result helpers, lazy catalog iterators, full table descriptions, and clearer statement lifecycle methods
- make statement status I/O explicit: `last_status()` reads the local snapshot, while async `status().await` performs one remote check and `wait().await` polls to completion
- add canonical streaming-write builder names plus `max_batch_rows`, while retaining the previous names as deprecated source-compatible aliases
- preserve server error messages and expose HTTP status, request ID, retryability, and `Retry-After`; only retry safely rejected append batches and keep unknown outcomes non-retryable
- reorganize runnable examples around query/catalog discovery, direct append, asynchronous batching, bulk import, telemetry, and detached statements
- raise the minimum supported Rust version from 1.85.0 to 1.91.0 so lockfile-free consumers can resolve the current dependency graph

## Compatibility and scope

- **Breaking:** Rust 1.91.0 or later is now required
- **Breaking:** the synchronous `StatementHandle::status()` snapshot accessor becomes `last_status()`; `status().await` is now the remote status operation
- released `fetch_once()` and `fetch()` remain deprecated forwarding aliases; the unreleased `refresh()` name is not exposed
- existing constructors, explicit catalog page methods, and other legacy method names remain available
- no SDK version bump
- no public health or hosted-product API
- no ScopeDB product version declaration
- no changes to `ingest_stream` retry behavior

## Validation

- `cargo +nightly fmt --all -- --check`
- `cargo +nightly clippy --all-targets --all-features -- -D warnings`
- `cargo +1.91.0 test --all-targets --all-features` (46 unit + 2 public API tests)
- `cargo +1.91.0 test --doc --all-features`
- `RUSTDOCFLAGS="-D warnings" cargo +1.91.0 doc --no-deps --all-features --document-private-items`
- `cargo +1.91.0 package --allow-dirty --no-verify`
- lockfile-free fresh consumer resolved current dependencies and passed `cargo +1.91.0 check --locked`
- live ScopeDB smoke: catalog, direct NDJSON append, 4-batch concurrent streaming write, query/result conversion, 422 and 401 error boundaries, and verified cleanup with zero disposable-table residue
- independent final review: no findings