### PR TITLE
docs(rust): add crate root guide

### DIFF
--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -38,6 +38,8 @@ All significant changes to the ScopeDB Rust SDK are documented in this file.
 
 ### Documentation
 
+* Added the user guide to the crate root so docs.rs starts with installation,
+  query, catalog, streaming-write, and error-handling paths.
 * Reworked runnable examples around read-only discovery, direct append,
   asynchronous batching, bulk imports, and best-effort telemetry journeys.
 

--- a/rust/README.md
+++ b/rust/README.md
@@ -19,7 +19,7 @@ Use the builder for the common API-key path. An API key is a server credential:
 keep it in a trusted process and never compile or return it to an untrusted
 client.
 
-```rust
+```rust,no_run
 use scopedb_client::Client;
 
 let client = Client::builder("http://127.0.0.1:6543")

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![doc = include_str!("../README.md")]
+
 mod append_stream;
 mod catalog;
 mod client;


### PR DESCRIPTION
## Summary

- render the Rust SDK user guide as crate-level documentation
- keep docs.rs and the repository README on one source of truth
- compile the API-key setup example without executing its environment lookup during doctests
- record the docs.rs landing-page change in the changelog

## Root cause

`rust/src/lib.rs` did not define any crate-level documentation, so docs.rs opened directly on the re-export and item index even though the repository README already described the complete SDK journey.

## Developer impact

The crate landing page now starts with installation, trusted API-key setup, ScopeQL links, queries, statement lifecycle, catalog discovery, NDJSON append, asynchronous append streams, delivery/error semantics, and runnable examples.

## Validation

- `cargo +1.91.0 test --doc --all-features` (10 doctests)
- `cargo +nightly fmt --all --check`
- `cargo +nightly clippy --locked --tests --all-targets --all-features -- -D warnings`
- `cargo +1.91.0 test --locked --all-targets --all-features` (48 tests)
- `RUSTDOCFLAGS="-D warnings" cargo +1.91.0 doc --locked --no-deps --all-features`
- generated rustdoc landing-page heading/ToC inspection
- `cargo +1.91.0 package --locked --allow-dirty`
- independent diff and docs review